### PR TITLE
Add product CRUD with search and RBAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@
 7. Normal kullanıcı ile 403 örneği:
    `USER_TOKEN=<user_token>`
    `curl -i http://localhost:8000/users -H "Authorization: Bearer $USER_TOKEN"`
+8. Ürün CRUD örnekleri:
+   `curl -s -X POST http://localhost:8000/products \\
+     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\
+     -d '{"name":"Sample","sku":"SKU123","price":9.99}'`
+   `curl -s http://localhost:8000/products -H "Authorization: Bearer $TOKEN"`
+   `PROD_ID=<dönen_id>`
+   `curl -s http://localhost:8000/products/$PROD_ID -H "Authorization: Bearer $TOKEN"`
+   `curl -s -X PUT http://localhost:8000/products/$PROD_ID \\
+     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\
+     -d '{"price":19.99}'`
+   `curl -s -X DELETE http://localhost:8000/products/$PROD_ID -H "Authorization: Bearer $TOKEN"`
 
 > Port çakışması notu: Lokal Postgres 5432 kullanıyorsa compose dosyasında `5432:5432` yerine `5433:5432` map et.
 

--- a/backend/alembic/versions/0003_create_products.py
+++ b/backend/alembic/versions/0003_create_products.py
@@ -1,0 +1,41 @@
+"""create products table"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0003"
+down_revision = "0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute('CREATE EXTENSION IF NOT EXISTS "pgcrypto"')
+    op.create_table(
+        "products",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("sku", sa.Text(), nullable=False, unique=True),
+        sa.Column("price", sa.Numeric(12, 2), nullable=False, server_default=sa.text("0")),
+        sa.Column(
+            "is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")
+        ),
+        sa.Column(
+            "created_at_utc",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("products")
+    op.execute('DROP EXTENSION IF EXISTS "pgcrypto"')

--- a/backend/app/api/products.py
+++ b/backend/app/api/products.py
@@ -1,0 +1,97 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.deps import (
+    get_current_admin,
+    get_current_user,
+    get_db,
+    get_pagination,
+)
+from app.models.user import User
+from app.schemas.product import (
+    ProductCreate,
+    ProductListResponse,
+    ProductPublic,
+    ProductUpdate,
+)
+from app.services.product_service import (
+    create_product,
+    delete_product,
+    get_product,
+    list_products,
+    update_product,
+)
+
+router = APIRouter(prefix="/products", tags=["products"])
+
+
+@router.get("", response_model=ProductListResponse)
+def list_products_endpoint(
+    pagination: tuple[int, int] = Depends(get_pagination),
+    search: str | None = None,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    page, page_size = pagination
+    items, total = list_products(db, page, page_size, search)
+    return {"items": items, "total": total, "page": page, "page_size": page_size}
+
+
+@router.get("/{product_id}", response_model=ProductPublic)
+def get_product_endpoint(
+    product_id: UUID,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    product = get_product(db, product_id)
+    if not product:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+    return product
+
+
+@router.post("", response_model=ProductPublic, status_code=status.HTTP_201_CREATED)
+def create_product_endpoint(
+    data: ProductCreate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    if data.price < 0:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Price must be non-negative")
+    try:
+        product = create_product(db, data)
+    except IntegrityError:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="SKU already exists")
+    return product
+
+
+@router.put("/{product_id}", status_code=status.HTTP_204_NO_CONTENT)
+def update_product_endpoint(
+    product_id: UUID,
+    data: ProductUpdate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    if data.price is not None and data.price < 0:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Price must be non-negative")
+    try:
+        product = update_product(db, product_id, data)
+    except IntegrityError:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="SKU already exists")
+    if not product:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.delete("/{product_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_product_endpoint(
+    product_id: UUID,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    deleted = delete_product(db, product_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -3,4 +3,4 @@ from sqlalchemy.orm import declarative_base
 Base = declarative_base()
 
 # Import models to register with SQLAlchemy metadata
-from app.models import user  # noqa: E402,F401
+from app.models import product, user  # noqa: E402,F401

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI
 from app.api.auth import router as auth_router
 from app.api.health import router as health_router
 from app.api.users import router as users_router
+from app.api.products import router as products_router
 from app.core.security import hash_password
 from app.core.config import settings
 from app.db.session import SessionLocal
@@ -28,3 +29,4 @@ def startup_event():
 app.include_router(auth_router)
 app.include_router(health_router)
 app.include_router(users_router)
+app.include_router(products_router)

--- a/backend/app/models/product.py
+++ b/backend/app/models/product.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Boolean, Column, DateTime, Numeric, Text, func, text
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.base import Base
+
+
+class Product(Base):
+    __tablename__ = "products"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()"))
+    name = Column(Text, nullable=False)
+    sku = Column(Text, nullable=False, unique=True)
+    price = Column(Numeric(12, 2), nullable=False, server_default=text("0"))
+    is_active = Column(Boolean, nullable=False, server_default=text("true"))
+    created_at_utc = Column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/backend/app/schemas/product.py
+++ b/backend/app/schemas/product.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+from decimal import Decimal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.common import PageMeta
+
+
+class ProductBase(BaseModel):
+    name: str = Field(..., min_length=2, max_length=120)
+    sku: str = Field(..., pattern=r"^[A-Za-z0-9_-]{3,40}$")
+    price: Decimal = Field(..., ge=0)
+    is_active: bool = True
+
+
+class ProductCreate(ProductBase):
+    pass
+
+
+class ProductUpdate(BaseModel):
+    name: str | None = Field(None, min_length=2, max_length=120)
+    sku: str | None = Field(None, pattern=r"^[A-Za-z0-9_-]{3,40}$")
+    price: Decimal | None = Field(None, ge=0)
+    is_active: bool | None = None
+
+
+class ProductPublic(BaseModel):
+    id: UUID
+    name: str
+    sku: str
+    price: Decimal
+    is_active: bool
+    created_at_utc: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ProductListResponse(PageMeta):
+    items: list[ProductPublic]

--- a/backend/app/services/product_service.py
+++ b/backend/app/services/product_service.py
@@ -1,0 +1,68 @@
+from typing import Sequence
+from uuid import UUID
+
+from sqlalchemy import or_
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.product import Product
+from app.schemas.product import ProductCreate, ProductUpdate
+
+
+def create_product(db: Session, data: ProductCreate) -> Product:
+    product = Product(**data.model_dump())
+    db.add(product)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise
+    db.refresh(product)
+    return product
+
+
+def get_product(db: Session, id: UUID) -> Product | None:
+    return db.get(Product, id)
+
+
+def list_products(
+    db: Session, page: int, page_size: int, search: str | None = None
+) -> tuple[Sequence[Product], int]:
+    query = db.query(Product)
+    if search:
+        like = f"%{search}%"
+        query = query.filter(
+            or_(Product.name.ilike(like), Product.sku.ilike(like))
+        )
+    total = query.count()
+    items = (
+        query.order_by(Product.created_at_utc.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+    return items, total
+
+
+def update_product(db: Session, id: UUID, data: ProductUpdate) -> Product | None:
+    product = db.get(Product, id)
+    if not product:
+        return None
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(product, field, value)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise
+    db.refresh(product)
+    return product
+
+
+def delete_product(db: Session, id: UUID) -> bool:
+    product = db.get(Product, id)
+    if not product:
+        return False
+    db.delete(product)
+    db.commit()
+    return True

--- a/backend/tests/api/test_products.py
+++ b/backend/tests/api/test_products.py
@@ -1,0 +1,134 @@
+from app.db.session import SessionLocal
+from app.models.product import Product
+
+
+def seed_products():
+    db = SessionLocal()
+    products = [
+        Product(name="Alpha", sku="ALPHA", price=1),
+        Product(name="Beta", sku="BETA", price=2),
+        Product(name="Gamma", sku="GAMMA", price=3),
+    ]
+    db.add_all(products)
+    db.commit()
+    db.close()
+
+
+def test_admin_can_create_and_get_product(client, admin_token):
+    payload = {"name": "Widget", "sku": "WID123", "price": 10}
+    res = client.post(
+        "/products",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=payload,
+    )
+    assert res.status_code == 201
+    data = res.json()
+    prod_id = data["id"]
+    assert data["sku"] == "WID123"
+
+    res_get = client.get(
+        f"/products/{prod_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert res_get.status_code == 200
+    assert res_get.json()["id"] == prod_id
+
+
+def test_list_products_pagination_search(client, user_token):
+    seed_products()
+    res = client.get(
+        "/products",
+        headers={"Authorization": f"Bearer {user_token}"},
+        params={"page": 1, "page_size": 2},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["total"] == 3
+    assert len(body["items"]) == 2
+
+    res_search = client.get(
+        "/products",
+        headers={"Authorization": f"Bearer {user_token}"},
+        params={"search": "beta"},
+    )
+    assert res_search.status_code == 200
+    body_search = res_search.json()
+    assert body_search["total"] == 1
+    assert body_search["items"][0]["sku"] == "BETA"
+
+
+def test_duplicate_sku_conflict(client, admin_token):
+    payload = {"name": "Item", "sku": "DUP1", "price": 5}
+    res1 = client.post(
+        "/products",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=payload,
+    )
+    assert res1.status_code == 201
+    res2 = client.post(
+        "/products",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=payload,
+    )
+    assert res2.status_code == 409
+
+
+def test_user_cannot_crud_product(client, user_token, admin_token):
+    payload = {"name": "UserProd", "sku": "USR1", "price": 1}
+    res = client.post(
+        "/products",
+        headers={"Authorization": f"Bearer {user_token}"},
+        json=payload,
+    )
+    assert res.status_code == 403
+
+    # create as admin for further tests
+    admin_res = client.post(
+        "/products",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=payload,
+    )
+    prod_id = admin_res.json()["id"]
+
+    res_put = client.put(
+        f"/products/{prod_id}",
+        headers={"Authorization": f"Bearer {user_token}"},
+        json={"price": 2},
+    )
+    assert res_put.status_code == 403
+
+    res_del = client.delete(
+        f"/products/{prod_id}", headers={"Authorization": f"Bearer {user_token}"}
+    )
+    assert res_del.status_code == 403
+
+
+def test_admin_update_and_delete_product(client, admin_token):
+    payload = {"name": "ToUpdate", "sku": "UPD1", "price": 3}
+    res = client.post(
+        "/products",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=payload,
+    )
+    prod_id = res.json()["id"]
+
+    res_put = client.put(
+        f"/products/{prod_id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"price": 4},
+    )
+    assert res_put.status_code == 204
+
+    res_get = client.get(
+        f"/products/{prod_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert float(res_get.json()["price"]) == 4
+
+    res_del = client.delete(
+        f"/products/{prod_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert res_del.status_code == 204
+
+    res_get2 = client.get(
+        f"/products/{prod_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert res_get2.status_code == 404


### PR DESCRIPTION
## Summary
- add products table and ORM model
- implement product schemas, service layer and REST API with search & pagination
- document product CRUD usage

## Testing
- `ruff check backend/app/api/products.py backend/app/models/product.py backend/app/schemas/product.py backend/app/services/product_service.py backend/tests/api/test_products.py backend/app/db/base.py backend/app/main.py backend/alembic/versions/0003_create_products.py`
- `pytest -q` *(fails: The starlette.testclient module requires the httpx package to be installed)*
- `alembic upgrade head` *(fails: KeyError: 'formatters')*

------
https://chatgpt.com/codex/tasks/task_e_68ac0a0f7ec8832d98ddf939bc441f51