### PR TITLE
Add httpx dependency and fix Alembic logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,10 @@
 docker compose -f ops/docker-compose.yml up -d --build
 docker compose -f ops/docker-compose.yml exec backend pytest -q
 ```
+
+## Test ve migration
+
+Hızlı komutlar:
+
+- `pytest -q`  (httpx artık mevcut olmalı)
+- `alembic upgrade head`  (formatters hatası çözülmüş olacak)

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,6 +1,36 @@
 [alembic]
 script_location = alembic
-sqlalchemy.url = %(DATABASE_URL)s
+prepend_sys_path = .
+sqlalchemy.url = ${DATABASE_URL}
 
-[logging]
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+
+[logger_alembic]
 level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,4 @@ passlib[bcrypt]==1.7.4
 python-jose[cryptography]==3.3.0
 email-validator==2.1.0.post1
 pydantic[email]==2.7.1
+httpx


### PR DESCRIPTION
## Summary
- add httpx to main backend requirements
- replace Alembic config with minimal logging setup
- document quick test and migration commands

## Testing
- `pip install -r backend/requirements.txt` *(fails: Could not connect to proxy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `cd backend && alembic upgrade head` *(fails: sqlite3.OperationalError: near "EXTENSION": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0d142ed8832d9f65bfde2eaee999