### PR TITLE
Enforce Postgres usage and guard Alembic migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@
 
 > Port çakışması notu: Lokal Postgres 5432 kullanıyorsa compose dosyasında `5432:5432` yerine `5433:5432` map et.
 
+> **Not:** Uygulama Postgres gerektirir. `DATABASE_URL` "postgresql" ile başlamıyorsa `RuntimeError("PostgreSQL required; run inside docker-compose")` fırlatır.
+
 ## Alembic Komut Örnekleri
 
 - `docker compose -f ops/docker-compose.yml exec backend alembic upgrade head`
@@ -43,9 +45,15 @@ docker compose -f ops/docker-compose.yml up -d --build
 docker compose -f ops/docker-compose.yml exec backend pytest -q
 ```
 
-## Test ve migration
+## Sadece container içinde çalıştır
 
-Hızlı komutlar:
+Aşağıdaki komutları kendi makinenizde değil, mutlaka container içinde çalıştırın:
 
-- `pytest -q`  (httpx artık mevcut olmalı)
-- `alembic upgrade head`  (formatters hatası çözülmüş olacak)
+```
+cp ops/.env.example ops/.env
+docker compose -f ops/docker-compose.yml up -d --build
+docker compose -f ops/docker-compose.yml exec backend alembic upgrade head
+docker compose -f ops/docker-compose.yml exec backend pytest -q
+```
+
+Lokal makinede `alembic upgrade head` veya `pytest` çalıştırmayın.

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,5 +1,4 @@
 from logging.config import fileConfig
-import os
 
 from sqlalchemy import engine_from_config, pool
 from alembic import context
@@ -15,7 +14,12 @@ if config.config_file_name is not None:
 
 target_metadata = Base.metadata
 
+is_pg = False
+
+
 def run_migrations_offline() -> None:
+    global is_pg
+    is_pg = settings.DATABASE_URL.startswith("postgresql")
     context.configure(
         url=settings.DATABASE_URL,
         target_metadata=target_metadata,
@@ -26,7 +30,9 @@ def run_migrations_offline() -> None:
     with context.begin_transaction():
         context.run_migrations()
 
+
 def run_migrations_online() -> None:
+    global is_pg
     connectable = engine_from_config(
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",
@@ -35,9 +41,12 @@ def run_migrations_online() -> None:
 
     with connectable.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)
+        bind = context.get_bind()
+        is_pg = bind and bind.dialect.name == "postgresql"
 
         with context.begin_transaction():
             context.run_migrations()
+
 
 if context.is_offline_mode():
     run_migrations_offline()

--- a/backend/alembic/versions/0002_create_users.py
+++ b/backend/alembic/versions/0002_create_users.py
@@ -12,7 +12,10 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute("CREATE EXTENSION IF NOT EXISTS citext")
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        op.execute('CREATE EXTENSION IF NOT EXISTS "pgcrypto";')
+        op.execute('CREATE EXTENSION IF NOT EXISTS "citext";')
     op.create_table(
         "users",
         sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
@@ -27,5 +30,8 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_table("users")
-    op.execute("DROP EXTENSION IF EXISTS citext")
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        op.execute('DROP EXTENSION IF EXISTS "citext";')
+        op.execute('DROP EXTENSION IF EXISTS "pgcrypto";')
 

--- a/backend/alembic/versions/0003_create_products.py
+++ b/backend/alembic/versions/0003_create_products.py
@@ -12,7 +12,9 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute('CREATE EXTENSION IF NOT EXISTS "pgcrypto"')
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        op.execute('CREATE EXTENSION IF NOT EXISTS "pgcrypto";')
     op.create_table(
         "products",
         sa.Column(
@@ -38,4 +40,6 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_table("products")
-    op.execute('DROP EXTENSION IF EXISTS "pgcrypto"')
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        op.execute('DROP EXTENSION IF EXISTS "pgcrypto";')

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from dotenv import load_dotenv
+from pydantic import model_validator
 from pydantic_settings import BaseSettings
 
 # Load .env files if present
@@ -16,6 +17,14 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
     ADMIN_EMAIL: str
     ADMIN_PASSWORD: str
+
+    @model_validator(mode="after")
+    def _ensure_postgres(self) -> "Settings":
+        if self.APP_ENV != "test" and not self.DATABASE_URL.startswith("postgresql"):
+            raise RuntimeError(
+                "PostgreSQL required; run inside docker-compose"
+            )
+        return self
 
 
 settings = Settings()

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -1,7 +1,8 @@
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
-POSTGRES_DB=postgres
-DATABASE_URL=postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+APP_ENV=local
+POSTGRES_USER=erp_user
+POSTGRES_PASSWORD=erp_pass
+POSTGRES_DB=erp
+DATABASE_URL=postgresql+psycopg://erp_user:erp_pass@postgres:5432/erp
 SECRET_KEY=change_me_in_local
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 ADMIN_EMAIL=admin@example.com


### PR DESCRIPTION
## Summary
- ensure configuration errors if not using PostgreSQL outside tests
- guard Alembic environment and migrations to skip Postgres-only extensions on other dialects
- document running migrations and tests only within Docker

## Testing
- `APP_ENV=test pytest -q` *(fails: The starlette.testclient module requires the httpx package to be installed)*
- `APP_ENV=test DATABASE_URL=sqlite:////tmp/test.db SECRET_KEY=x ADMIN_EMAIL=a ADMIN_PASSWORD=b alembic upgrade head` *(fails: Compiler can't render element of type UUID)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0e76777c832db95201b103caacb2