### PR TITLE
Add categories module with hierarchical CRUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@
      -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\
      -d '{"price":19.99}'`
    `curl -s -X DELETE http://localhost:8000/products/$PROD_ID -H "Authorization: Bearer $TOKEN"`
+9. Kategori CRUD örnekleri:
+   `curl -s -X POST http://localhost:8000/categories \\
+     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\
+     -d '{"name":"Electronics","code":"ELEC"}'`
+   `curl -s http://localhost:8000/categories -H "Authorization: Bearer $TOKEN"`
+   `CAT_ID=<dönen_id>`
+   `curl -s http://localhost:8000/categories/$CAT_ID -H "Authorization: Bearer $TOKEN"`
+   `curl -s -X PUT http://localhost:8000/categories/$CAT_ID \\
+     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\
+     -d '{"name":"NewName"}'`
+   `curl -s -X DELETE http://localhost:8000/categories/$CAT_ID -H "Authorization: Bearer $TOKEN"`
 
 > Port çakışması notu: Lokal Postgres 5432 kullanıyorsa compose dosyasında `5432:5432` yerine `5433:5432` map et.
 

--- a/backend/alembic/versions/0004_create_categories.py
+++ b/backend/alembic/versions/0004_create_categories.py
@@ -1,0 +1,49 @@
+"""create categories table"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0004"
+down_revision = "0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        op.execute('CREATE EXTENSION IF NOT EXISTS "pgcrypto";')
+    op.create_table(
+        "categories",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("code", sa.Text(), nullable=True, unique=True),
+        sa.Column(
+            "parent_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("categories.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "created_at_utc",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint("name", "parent_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("categories")
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        op.execute('DROP EXTENSION IF EXISTS "pgcrypto";')

--- a/backend/app/api/categories.py
+++ b/backend/app/api/categories.py
@@ -1,0 +1,104 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.deps import (
+    get_current_admin,
+    get_current_user,
+    get_db,
+    get_pagination,
+)
+from app.models.user import User
+from app.schemas.category import (
+    CategoryCreate,
+    CategoryListResponse,
+    CategoryPublic,
+    CategoryUpdate,
+)
+from app.services.category_service import (
+    create_category,
+    delete_category,
+    get_category,
+    list_categories,
+    update_category,
+)
+
+router = APIRouter(prefix="/categories", tags=["categories"])
+
+
+@router.get("", response_model=CategoryListResponse)
+def list_categories_endpoint(
+    pagination: tuple[int, int] = Depends(get_pagination),
+    search: str | None = None,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    page, page_size = pagination
+    items, total = list_categories(db, page, page_size, search)
+    return {"items": items, "total": total, "page": page, "page_size": page_size}
+
+
+@router.get("/{category_id}", response_model=CategoryPublic)
+def get_category_endpoint(
+    category_id: UUID,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    category = get_category(db, category_id)
+    if not category:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found")
+    return category
+
+
+@router.post("", response_model=CategoryPublic, status_code=status.HTTP_201_CREATED)
+def create_category_endpoint(
+    data: CategoryCreate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    try:
+        category = create_category(db, data)
+    except IntegrityError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Category with this name or code already exists",
+        )
+    return category
+
+
+@router.put("/{category_id}", status_code=status.HTTP_204_NO_CONTENT)
+def update_category_endpoint(
+    category_id: UUID,
+    data: CategoryUpdate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    if data.parent_id is not None and data.parent_id == category_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="parent_id cannot be the same as id",
+        )
+    try:
+        category = update_category(db, category_id, data)
+    except IntegrityError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Category with this name or code already exists",
+        )
+    if not category:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.delete("/{category_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_category_endpoint(
+    category_id: UUID,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    deleted = delete_category(db, category_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -3,4 +3,4 @@ from sqlalchemy.orm import declarative_base
 Base = declarative_base()
 
 # Import models to register with SQLAlchemy metadata
-from app.models import product, user  # noqa: E402,F401
+from app.models import category, product, user  # noqa: E402,F401

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from app.api.auth import router as auth_router
 from app.api.health import router as health_router
 from app.api.users import router as users_router
 from app.api.products import router as products_router
+from app.api.categories import router as categories_router
 from app.core.security import hash_password
 from app.core.config import settings
 from app.db.session import SessionLocal
@@ -30,3 +31,4 @@ app.include_router(auth_router)
 app.include_router(health_router)
 app.include_router(users_router)
 app.include_router(products_router)
+app.include_router(categories_router)

--- a/backend/app/models/category.py
+++ b/backend/app/models/category.py
@@ -1,0 +1,20 @@
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Text, UniqueConstraint, func, text
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.base import Base
+
+
+class Category(Base):
+    __tablename__ = "categories"
+    __table_args__ = (UniqueConstraint("name", "parent_id"),)
+
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()"))
+    name = Column(Text, nullable=False)
+    code = Column(Text, unique=True, nullable=True)
+    parent_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("categories.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    is_active = Column(Boolean, nullable=False, server_default=text("true"))
+    created_at_utc = Column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/backend/app/schemas/category.py
+++ b/backend/app/schemas/category.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.common import PageMeta
+
+
+class CategoryBase(BaseModel):
+    name: str = Field(..., min_length=2, max_length=80)
+    code: str | None = Field(None, pattern=r"^[A-Za-z0-9_-]{2,20}$")
+    parent_id: UUID | None = None
+    is_active: bool = True
+
+
+class CategoryCreate(CategoryBase):
+    pass
+
+
+class CategoryUpdate(BaseModel):
+    name: str | None = Field(None, min_length=2, max_length=80)
+    code: str | None = Field(None, pattern=r"^[A-Za-z0-9_-]{2,20}$")
+    parent_id: UUID | None = None
+    is_active: bool | None = None
+
+
+class CategoryPublic(BaseModel):
+    id: UUID
+    name: str
+    code: str | None
+    parent_id: UUID | None
+    is_active: bool
+    created_at_utc: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CategoryListResponse(PageMeta):
+    items: list[CategoryPublic]

--- a/backend/app/services/category_service.py
+++ b/backend/app/services/category_service.py
@@ -1,0 +1,68 @@
+from typing import Sequence
+from uuid import UUID
+
+from sqlalchemy import or_
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.category import Category
+from app.schemas.category import CategoryCreate, CategoryUpdate
+
+
+def create_category(db: Session, data: CategoryCreate) -> Category:
+    category = Category(**data.model_dump())
+    db.add(category)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise
+    db.refresh(category)
+    return category
+
+
+def get_category(db: Session, id: UUID) -> Category | None:
+    return db.get(Category, id)
+
+
+def list_categories(
+    db: Session, page: int, page_size: int, search: str | None = None
+) -> tuple[Sequence[Category], int]:
+    query = db.query(Category)
+    if search:
+        like = f"%{search}%"
+        query = query.filter(
+            or_(Category.name.ilike(like), Category.code.ilike(like))
+        )
+    total = query.count()
+    items = (
+        query.order_by(Category.created_at_utc.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+    return items, total
+
+
+def update_category(db: Session, id: UUID, data: CategoryUpdate) -> Category | None:
+    category = db.get(Category, id)
+    if not category:
+        return None
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(category, field, value)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise
+    db.refresh(category)
+    return category
+
+
+def delete_category(db: Session, id: UUID) -> bool:
+    category = db.get(Category, id)
+    if not category:
+        return False
+    db.delete(category)
+    db.commit()
+    return True

--- a/backend/tests/api/test_categories.py
+++ b/backend/tests/api/test_categories.py
@@ -1,0 +1,82 @@
+from app.db.session import SessionLocal
+from app.models.category import Category
+
+
+def seed_categories():
+    db = SessionLocal()
+    categories = [
+        Category(name="Alpha", code="ALPHA"),
+        Category(name="Beta", code="BETA"),
+        Category(name="Gamma", code="GAMMA"),
+    ]
+    db.add_all(categories)
+    db.commit()
+    db.close()
+
+
+def test_admin_can_create_and_get_category(client, admin_token):
+    payload = {"name": "Electronics", "code": "ELEC"}
+    res = client.post(
+        "/categories",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=payload,
+    )
+    assert res.status_code == 201
+    data = res.json()
+    cat_id = data["id"]
+    assert data["code"] == "ELEC"
+
+    res_get = client.get(
+        f"/categories/{cat_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert res_get.status_code == 200
+    assert res_get.json()["id"] == cat_id
+
+
+def test_list_categories_pagination_search(client, user_token):
+    seed_categories()
+    res = client.get(
+        "/categories",
+        headers={"Authorization": f"Bearer {user_token}"},
+        params={"page": 1, "page_size": 2},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["total"] == 3
+    assert len(body["items"]) == 2
+
+    res_search = client.get(
+        "/categories",
+        headers={"Authorization": f"Bearer {user_token}"},
+        params={"search": "beta"},
+    )
+    assert res_search.status_code == 200
+    body_search = res_search.json()
+    assert body_search["total"] == 1
+    assert body_search["items"][0]["code"] == "BETA"
+
+
+def test_user_cannot_create_category(client, user_token):
+    payload = {"name": "UserCat", "code": "USRC"}
+    res = client.post(
+        "/categories",
+        headers={"Authorization": f"Bearer {user_token}"},
+        json=payload,
+    )
+    assert res.status_code == 403
+
+
+def test_duplicate_category_conflict(client, admin_token):
+    payload = {"name": "Dup", "code": "DUP1"}
+    res1 = client.post(
+        "/categories",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=payload,
+    )
+    assert res1.status_code == 201
+    res2 = client.post(
+        "/categories",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=payload,
+    )
+    assert res2.status_code == 409


### PR DESCRIPTION
## Summary
- add Category model, schemas, service and API with RBAC and search
- include categories router and migration
- document category CRUD curl examples and tests

## Testing
- `APP_ENV=test SECRET_KEY=test ADMIN_EMAIL=a ADMIN_PASSWORD=b DATABASE_URL=postgresql://user:pass@localhost/db alembic upgrade head --sql`
- `pytest -q` *(fails: httpx missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0fef3960832d8f2910395bcbcd40