### PR TITLE
Add warehouse and stock movement tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@
      -d '{"name":"NewName"}'`
    `curl -s -X DELETE http://localhost:8000/categories/$CAT_ID -H "Authorization: Bearer $TOKEN"`
 
+10. Depo ve stok hareketi örnekleri:
+   `curl -s -X POST http://localhost:8000/warehouses \\
+     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\
+     -d '{"name":"Main","code":"MAIN"}'`
+   `curl -s http://localhost:8000/warehouses -H "Authorization: Bearer $TOKEN"`
+   `WH_ID=<dönen_id>`
+   `PROD_ID=<önceden_oluşturulan_urun_id>`
+   `curl -s -X POST http://localhost:8000/stock-movements \\
+     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\
+     -d '{"product_id":"'$PROD_ID'","warehouse_id":"'$WH_ID'","direction":"IN","quantity":5}'`
+   `curl -s -X POST http://localhost:8000/stock-movements \\
+     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\
+     -d '{"product_id":"'$PROD_ID'","warehouse_id":"'$WH_ID'","direction":"OUT","quantity":2}'`
+   `curl -i -X POST http://localhost:8000/stock-movements \\
+     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\
+     -d '{"product_id":"'$PROD_ID'","warehouse_id":"'$WH_ID'","direction":"OUT","quantity":99}'`
+   `curl -s http://localhost:8000/stock/product/$PROD_ID -H "Authorization: Bearer $TOKEN"`
+
 > Port çakışması notu: Lokal Postgres 5432 kullanıyorsa compose dosyasında `5432:5432` yerine `5433:5432` map et.
 
 > **Not:** Uygulama Postgres gerektirir. `DATABASE_URL` "postgresql" ile başlamıyorsa `RuntimeError("PostgreSQL required; run inside docker-compose")` fırlatır.

--- a/backend/alembic/versions/0005_create_warehouses_and_stock_movements.py
+++ b/backend/alembic/versions/0005_create_warehouses_and_stock_movements.py
@@ -1,0 +1,107 @@
+"""create warehouses and stock movements tables"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0005"
+down_revision = "0004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        op.execute('CREATE EXTENSION IF NOT EXISTS "pgcrypto";')
+
+    op.create_table(
+        "warehouses",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("name", sa.Text(), nullable=False, unique=True),
+        sa.Column("code", sa.Text(), nullable=True, unique=True),
+        sa.Column(
+            "is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")
+        ),
+        sa.Column(
+            "created_at_utc",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    op.create_table(
+        "stock_movements",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "product_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("products.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "warehouse_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("warehouses.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "direction",
+            sa.Text(),
+            nullable=False,
+        ),
+        sa.Column(
+            "quantity",
+            sa.Numeric(14, 3),
+            nullable=False,
+        ),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column("document_no", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at_utc",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint("direction IN ('IN','OUT')", name="chk_direction"),
+        sa.CheckConstraint("quantity > 0", name="chk_quantity_positive"),
+    )
+
+    op.create_index(
+        "ix_stock_movements_prod",
+        "stock_movements",
+        ["product_id"],
+    )
+    op.create_index(
+        "ix_stock_movements_wh",
+        "stock_movements",
+        ["warehouse_id"],
+    )
+    op.create_index(
+        "ix_stock_movements_created",
+        "stock_movements",
+        [sa.text("created_at_utc DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_stock_movements_created", table_name="stock_movements")
+    op.drop_index("ix_stock_movements_wh", table_name="stock_movements")
+    op.drop_index("ix_stock_movements_prod", table_name="stock_movements")
+    op.drop_table("stock_movements")
+    op.drop_table("warehouses")
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        op.execute('DROP EXTENSION IF EXISTS "pgcrypto";')

--- a/backend/app/api/stock.py
+++ b/backend/app/api/stock.py
@@ -1,0 +1,31 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.core.deps import get_current_user, get_db
+from app.models.product import Product
+from app.models.user import User
+from app.services.stock_movement_service import (
+    get_product_stock,
+    get_stock_by_warehouse,
+)
+
+router = APIRouter(prefix="/stock", tags=["stock"])
+
+
+@router.get("/product/{product_id}")
+def get_product_stock_endpoint(
+    product_id: UUID,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    product = db.get(Product, product_id)
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+    total = get_product_stock(db, product_id)
+    by_wh = [
+        {"warehouse_id": wid, "qty": qty}
+        for wid, qty in get_stock_by_warehouse(db, product_id)
+    ]
+    return {"product_id": product_id, "total": total, "by_warehouse": by_wh}

--- a/backend/app/api/stock_movements.py
+++ b/backend/app/api/stock_movements.py
@@ -1,0 +1,96 @@
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.deps import (
+    get_current_admin,
+    get_current_user,
+    get_db,
+    get_pagination,
+)
+from app.models.user import User
+from app.schemas.stock_movement import (
+    StockMovementCreate,
+    StockMovementListResponse,
+    StockMovementPublic,
+)
+from app.services.stock_movement_service import (
+    InsufficientStock,
+    create_movement,
+    delete_movement,
+    get_movement,
+    list_movements,
+)
+
+router = APIRouter(prefix="/stock-movements", tags=["stock-movements"])
+
+
+@router.get("", response_model=StockMovementListResponse)
+def list_movements_endpoint(
+    pagination: tuple[int, int] = Depends(get_pagination),
+    product_id: UUID | None = None,
+    warehouse_id: UUID | None = None,
+    direction: Literal["IN", "OUT"] | None = None,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    page, page_size = pagination
+    items, total = list_movements(
+        db,
+        page,
+        page_size,
+        product_id=product_id,
+        warehouse_id=warehouse_id,
+        direction=direction,
+        date_from=date_from,
+        date_to=date_to,
+    )
+    return {"items": items, "total": total, "page": page, "page_size": page_size}
+
+
+@router.get("/{movement_id}", response_model=StockMovementPublic)
+def get_movement_endpoint(
+    movement_id: UUID,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    movement = get_movement(db, movement_id)
+    if not movement:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Stock movement not found")
+    return movement
+
+
+@router.post("", response_model=StockMovementPublic, status_code=status.HTTP_201_CREATED)
+def create_movement_endpoint(
+    data: StockMovementCreate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    try:
+        movement = create_movement(db, data)
+    except InsufficientStock:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="insufficient_stock")
+    except IntegrityError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid product or warehouse",
+        )
+    return movement
+
+
+@router.delete("/{movement_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_movement_endpoint(
+    movement_id: UUID,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    deleted = delete_movement(db, movement_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Stock movement not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/warehouses.py
+++ b/backend/app/api/warehouses.py
@@ -1,0 +1,99 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.deps import (
+    get_current_admin,
+    get_current_user,
+    get_db,
+    get_pagination,
+)
+from app.models.user import User
+from app.schemas.warehouse import (
+    WarehouseCreate,
+    WarehouseListResponse,
+    WarehousePublic,
+    WarehouseUpdate,
+)
+from app.services.warehouse_service import (
+    create_warehouse,
+    delete_warehouse,
+    get_warehouse,
+    list_warehouses,
+    update_warehouse,
+)
+
+router = APIRouter(prefix="/warehouses", tags=["warehouses"])
+
+
+@router.get("", response_model=WarehouseListResponse)
+def list_warehouses_endpoint(
+    pagination: tuple[int, int] = Depends(get_pagination),
+    search: str | None = None,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    page, page_size = pagination
+    items, total = list_warehouses(db, page, page_size, search)
+    return {"items": items, "total": total, "page": page, "page_size": page_size}
+
+
+@router.get("/{warehouse_id}", response_model=WarehousePublic)
+def get_warehouse_endpoint(
+    warehouse_id: UUID,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    warehouse = get_warehouse(db, warehouse_id)
+    if not warehouse:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Warehouse not found")
+    return warehouse
+
+
+@router.post("", response_model=WarehousePublic, status_code=status.HTTP_201_CREATED)
+def create_warehouse_endpoint(
+    data: WarehouseCreate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    try:
+        warehouse = create_warehouse(db, data)
+    except IntegrityError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Warehouse with this name or code already exists",
+        )
+    return warehouse
+
+
+@router.put("/{warehouse_id}", status_code=status.HTTP_204_NO_CONTENT)
+def update_warehouse_endpoint(
+    warehouse_id: UUID,
+    data: WarehouseUpdate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    try:
+        warehouse = update_warehouse(db, warehouse_id, data)
+    except IntegrityError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Warehouse with this name or code already exists",
+        )
+    if not warehouse:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Warehouse not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.delete("/{warehouse_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_warehouse_endpoint(
+    warehouse_id: UUID,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    deleted = delete_warehouse(db, warehouse_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Warehouse not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -3,4 +3,10 @@ from sqlalchemy.orm import declarative_base
 Base = declarative_base()
 
 # Import models to register with SQLAlchemy metadata
-from app.models import category, product, user  # noqa: E402,F401
+from app.models import (
+    category,
+    product,
+    stock_movement,
+    user,
+    warehouse,
+)  # noqa: E402,F401

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,9 @@ from app.api.health import router as health_router
 from app.api.users import router as users_router
 from app.api.products import router as products_router
 from app.api.categories import router as categories_router
+from app.api.warehouses import router as warehouses_router
+from app.api.stock_movements import router as stock_movements_router
+from app.api.stock import router as stock_router
 from app.core.security import hash_password
 from app.core.config import settings
 from app.db.session import SessionLocal
@@ -32,3 +35,6 @@ app.include_router(health_router)
 app.include_router(users_router)
 app.include_router(products_router)
 app.include_router(categories_router)
+app.include_router(warehouses_router)
+app.include_router(stock_movements_router)
+app.include_router(stock_router)

--- a/backend/app/models/stock_movement.py
+++ b/backend/app/models/stock_movement.py
@@ -1,0 +1,34 @@
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Numeric,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.base import Base
+
+
+class StockMovement(Base):
+    __tablename__ = "stock_movements"
+    __table_args__ = (
+        Index("ix_stock_movements_prod", "product_id"),
+        Index("ix_stock_movements_wh", "warehouse_id"),
+        Index("ix_stock_movements_created", text("created_at_utc DESC")),
+        CheckConstraint("direction IN ('IN','OUT')", name="chk_direction"),
+        CheckConstraint("quantity > 0", name="chk_quantity_positive"),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()"))
+    product_id = Column(UUID(as_uuid=True), ForeignKey("products.id", ondelete="RESTRICT"), nullable=False)
+    warehouse_id = Column(UUID(as_uuid=True), ForeignKey("warehouses.id", ondelete="RESTRICT"), nullable=False)
+    direction = Column(Text, nullable=False)
+    quantity = Column(Numeric(14, 3), nullable=False)
+    reason = Column(Text, nullable=True)
+    document_no = Column(Text, nullable=True)
+    created_at_utc = Column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/backend/app/models/warehouse.py
+++ b/backend/app/models/warehouse.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Boolean, Column, DateTime, Text, func, text
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.base import Base
+
+
+class Warehouse(Base):
+    __tablename__ = "warehouses"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()"))
+    name = Column(Text, nullable=False, unique=True)
+    code = Column(Text, nullable=True, unique=True)
+    is_active = Column(Boolean, nullable=False, server_default=text("true"))
+    created_at_utc = Column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/backend/app/schemas/stock_movement.py
+++ b/backend/app/schemas/stock_movement.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+from decimal import Decimal
+from uuid import UUID
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.common import PageMeta
+
+
+class StockMovementBase(BaseModel):
+    product_id: UUID
+    warehouse_id: UUID
+    direction: Literal['IN', 'OUT']
+    quantity: Decimal = Field(..., gt=0)
+    reason: str | None = Field(None, max_length=60)
+    document_no: str | None = Field(None, max_length=40)
+
+
+class StockMovementCreate(StockMovementBase):
+    pass
+
+
+class StockMovementPublic(BaseModel):
+    id: UUID
+    product_id: UUID
+    warehouse_id: UUID
+    direction: Literal['IN', 'OUT']
+    quantity: Decimal
+    reason: str | None
+    document_no: str | None
+    created_at_utc: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class StockMovementListResponse(PageMeta):
+    items: list[StockMovementPublic]

--- a/backend/app/schemas/warehouse.py
+++ b/backend/app/schemas/warehouse.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.common import PageMeta
+
+
+class WarehouseBase(BaseModel):
+    name: str = Field(..., min_length=2, max_length=80)
+    code: str | None = Field(None, pattern=r"^[A-Za-z0-9_-]{2,20}$")
+    is_active: bool = True
+
+
+class WarehouseCreate(WarehouseBase):
+    pass
+
+
+class WarehouseUpdate(BaseModel):
+    name: str | None = Field(None, min_length=2, max_length=80)
+    code: str | None = Field(None, pattern=r"^[A-Za-z0-9_-]{2,20}$")
+    is_active: bool | None = None
+
+
+class WarehousePublic(BaseModel):
+    id: UUID
+    name: str
+    code: str | None
+    is_active: bool
+    created_at_utc: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class WarehouseListResponse(PageMeta):
+    items: list[WarehousePublic]

--- a/backend/app/services/stock_movement_service.py
+++ b/backend/app/services/stock_movement_service.py
@@ -1,0 +1,118 @@
+from datetime import datetime
+from decimal import Decimal
+from typing import Sequence
+from uuid import UUID
+
+from sqlalchemy import case, func
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.stock_movement import StockMovement
+from app.schemas.stock_movement import StockMovementCreate
+
+
+class InsufficientStock(Exception):
+    pass
+
+
+def get_product_stock(
+    db: Session, product_id: UUID, warehouse_id: UUID | None = None
+) -> Decimal:
+    query = db.query(
+        func.coalesce(
+            func.sum(
+                case(
+                    (StockMovement.direction == "IN", StockMovement.quantity),
+                    else_=-StockMovement.quantity,
+                )
+            ),
+            0,
+        )
+    ).filter(StockMovement.product_id == product_id)
+    if warehouse_id:
+        query = query.filter(StockMovement.warehouse_id == warehouse_id)
+    return query.scalar() or Decimal("0")
+
+
+def get_stock_by_warehouse(db: Session, product_id: UUID) -> list[tuple[UUID, Decimal]]:
+    rows = (
+        db.query(
+            StockMovement.warehouse_id,
+            func.coalesce(
+                func.sum(
+                    case(
+                        (StockMovement.direction == "IN", StockMovement.quantity),
+                        else_=-StockMovement.quantity,
+                    )
+                ),
+                0,
+            ).label("qty"),
+        )
+        .filter(StockMovement.product_id == product_id)
+        .group_by(StockMovement.warehouse_id)
+        .all()
+    )
+    return [(row.warehouse_id, row.qty) for row in rows]
+
+
+def create_movement(db: Session, data: StockMovementCreate) -> StockMovement:
+    if data.direction == "OUT":
+        total = get_product_stock(db, data.product_id)
+        if total - data.quantity < 0:
+            raise InsufficientStock
+        wh_total = get_product_stock(db, data.product_id, data.warehouse_id)
+        if wh_total - data.quantity < 0:
+            raise InsufficientStock
+    movement = StockMovement(**data.model_dump())
+    db.add(movement)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise
+    db.refresh(movement)
+    return movement
+
+
+def list_movements(
+    db: Session,
+    page: int,
+    page_size: int,
+    product_id: UUID | None = None,
+    warehouse_id: UUID | None = None,
+    direction: str | None = None,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
+) -> tuple[Sequence[StockMovement], int]:
+    query = db.query(StockMovement)
+    if product_id:
+        query = query.filter(StockMovement.product_id == product_id)
+    if warehouse_id:
+        query = query.filter(StockMovement.warehouse_id == warehouse_id)
+    if direction:
+        query = query.filter(StockMovement.direction == direction)
+    if date_from:
+        query = query.filter(StockMovement.created_at_utc >= date_from)
+    if date_to:
+        query = query.filter(StockMovement.created_at_utc <= date_to)
+    total = query.count()
+    items = (
+        query.order_by(StockMovement.created_at_utc.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+    return items, total
+
+
+def get_movement(db: Session, id: UUID) -> StockMovement | None:
+    return db.get(StockMovement, id)
+
+
+def delete_movement(db: Session, id: UUID) -> bool:
+    movement = db.get(StockMovement, id)
+    if not movement:
+        return False
+    db.delete(movement)
+    db.commit()
+    return True

--- a/backend/app/services/warehouse_service.py
+++ b/backend/app/services/warehouse_service.py
@@ -1,0 +1,66 @@
+from typing import Sequence
+from uuid import UUID
+
+from sqlalchemy import or_
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.warehouse import Warehouse
+from app.schemas.warehouse import WarehouseCreate, WarehouseUpdate
+
+
+def create_warehouse(db: Session, data: WarehouseCreate) -> Warehouse:
+    warehouse = Warehouse(**data.model_dump())
+    db.add(warehouse)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise
+    db.refresh(warehouse)
+    return warehouse
+
+
+def get_warehouse(db: Session, id: UUID) -> Warehouse | None:
+    return db.get(Warehouse, id)
+
+
+def list_warehouses(
+    db: Session, page: int, page_size: int, search: str | None = None
+) -> tuple[Sequence[Warehouse], int]:
+    query = db.query(Warehouse)
+    if search:
+        like = f"%{search}%"
+        query = query.filter(or_(Warehouse.name.ilike(like), Warehouse.code.ilike(like)))
+    total = query.count()
+    items = (
+        query.order_by(Warehouse.created_at_utc.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+    return items, total
+
+
+def update_warehouse(db: Session, id: UUID, data: WarehouseUpdate) -> Warehouse | None:
+    warehouse = db.get(Warehouse, id)
+    if not warehouse:
+        return None
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(warehouse, field, value)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise
+    db.refresh(warehouse)
+    return warehouse
+
+
+def delete_warehouse(db: Session, id: UUID) -> bool:
+    warehouse = db.get(Warehouse, id)
+    if not warehouse:
+        return False
+    db.delete(warehouse)
+    db.commit()
+    return True

--- a/backend/tests/api/test_warehouses_stock.py
+++ b/backend/tests/api/test_warehouses_stock.py
@@ -1,0 +1,123 @@
+from app.db.session import SessionLocal
+from app.models.product import Product
+from app.models.warehouse import Warehouse
+
+
+def seed_product_and_warehouse():
+    db = SessionLocal()
+    product = Product(name="Widget", sku="WIDG1", price=1)
+    warehouse = Warehouse(name="Main", code="MAIN")
+    db.add_all([product, warehouse])
+    db.commit()
+    db.refresh(product)
+    db.refresh(warehouse)
+    db.close()
+    return product, warehouse
+
+
+def test_warehouse_crud_and_rbac(client, admin_token, user_token):
+    # admin create
+    res = client.post(
+        "/warehouses",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"name": "Main", "code": "MAIN"},
+    )
+    assert res.status_code == 201
+    wid = res.json()["id"]
+
+    # user list
+    res_list = client.get(
+        "/warehouses", headers={"Authorization": f"Bearer {user_token}"}
+    )
+    assert res_list.status_code == 200
+    assert res_list.json()["total"] == 1
+
+    # user cannot create
+    res_user_create = client.post(
+        "/warehouses",
+        headers={"Authorization": f"Bearer {user_token}"},
+        json={"name": "X", "code": "X"},
+    )
+    assert res_user_create.status_code == 403
+
+    # admin update
+    res_put = client.put(
+        f"/warehouses/{wid}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"name": "Main2"},
+    )
+    assert res_put.status_code == 204
+
+    # admin delete
+    res_del = client.delete(
+        f"/warehouses/{wid}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert res_del.status_code == 204
+
+    res_get = client.get(
+        f"/warehouses/{wid}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert res_get.status_code == 404
+
+
+def test_stock_movements_and_stock_endpoint(client, admin_token, user_token):
+    product, warehouse = seed_product_and_warehouse()
+
+    payload_in = {
+        "product_id": str(product.id),
+        "warehouse_id": str(warehouse.id),
+        "direction": "IN",
+        "quantity": 5,
+    }
+    res_in = client.post(
+        "/stock-movements",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=payload_in,
+    )
+    assert res_in.status_code == 201
+
+    # stock check
+    res_stock = client.get(
+        f"/stock/product/{product.id}",
+        headers={"Authorization": f"Bearer {user_token}"},
+    )
+    assert res_stock.status_code == 200
+    body = res_stock.json()
+    assert body["total"] == 5
+    assert body["by_warehouse"][0]["qty"] == 5
+
+    # out movement success
+    payload_out = payload_in | {"direction": "OUT", "quantity": 2}
+    res_out = client.post(
+        "/stock-movements",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=payload_out,
+    )
+    assert res_out.status_code == 201
+
+    # out movement exceeding stock -> 409
+    payload_out_bad = payload_in | {"direction": "OUT", "quantity": 99}
+    res_out_bad = client.post(
+        "/stock-movements",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=payload_out_bad,
+    )
+    assert res_out_bad.status_code == 409
+    assert res_out_bad.json()["detail"] == "insufficient_stock"
+
+    # user cannot create movement
+    res_user = client.post(
+        "/stock-movements",
+        headers={"Authorization": f"Bearer {user_token}"},
+        json=payload_in,
+    )
+    assert res_user.status_code == 403
+
+    # user can list movements
+    res_list = client.get(
+        "/stock-movements",
+        headers={"Authorization": f"Bearer {user_token}"},
+        params={"product_id": str(product.id)},
+    )
+    assert res_list.status_code == 200
+    assert res_list.json()["total"] >= 2


### PR DESCRIPTION
## Summary
- introduce warehouses and stock movement tables with migration
- expose CRUD APIs for warehouses and stock movements with RBAC
- provide stock summary endpoint and helper services

## Testing
- `pytest -q` *(fails: RuntimeError: The starlette.testclient module requires the httpx package to be installed.)*


------
https://chatgpt.com/codex/tasks/task_e_68ac12c5e414832d9d1d41ef3afd2aca