### PR TITLE
Add partners module with CRUD API and RBAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@
      -d '{"product_id":"'$PROD_ID'","warehouse_id":"'$WH_ID'","direction":"OUT","quantity":99}'`
    `curl -s http://localhost:8000/stock/product/$PROD_ID -H "Authorization: Bearer $TOKEN"`
 
+11. Partner CRUD örnekleri:
+   `curl -s -X POST http://localhost:8000/partners \\
+     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\
+     -d '{"name":"Acme","type":"customer","tax_number":"TN123"}'`
+   `curl -s http://localhost:8000/partners -H "Authorization: Bearer $TOKEN"`
+   `PART_ID=<dönen_id>`
+   `curl -s http://localhost:8000/partners/$PART_ID -H "Authorization: Bearer $TOKEN"`
+   `curl -s -X PUT http://localhost:8000/partners/$PART_ID \\
+     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\
+     -d '{"phone":"555-0000"}'`
+   `curl -s -X DELETE http://localhost:8000/partners/$PART_ID -H "Authorization: Bearer $TOKEN"`
+
 > Port çakışması notu: Lokal Postgres 5432 kullanıyorsa compose dosyasında `5432:5432` yerine `5433:5432` map et.
 
 > **Not:** Uygulama Postgres gerektirir. `DATABASE_URL` "postgresql" ile başlamıyorsa `RuntimeError("PostgreSQL required; run inside docker-compose")` fırlatır.

--- a/backend/alembic/versions/0006_create_partners.py
+++ b/backend/alembic/versions/0006_create_partners.py
@@ -1,0 +1,63 @@
+"""create partners table"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0006"
+down_revision = "0005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        op.execute('CREATE EXTENSION IF NOT EXISTS "pgcrypto";')
+        op.execute('CREATE EXTENSION IF NOT EXISTS "citext";')
+    op.create_table(
+        "partners",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("type", sa.Text(), nullable=False),
+        sa.Column("email", postgresql.CITEXT(), nullable=True),
+        sa.Column("phone", sa.Text(), nullable=True),
+        sa.Column("tax_number", sa.Text(), nullable=True, unique=True),
+        sa.Column("billing_address", sa.Text(), nullable=True),
+        sa.Column("shipping_address", sa.Text(), nullable=True),
+        sa.Column(
+            "is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")
+        ),
+        sa.Column(
+            "created_at_utc",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint(
+            "type IN ('customer','supplier','both')",
+            name="chk_partner_type",
+        ),
+    )
+    op.create_index(
+        "ix_partners_name",
+        "partners",
+        [sa.text("lower(name)")],
+    )
+    op.create_index("ix_partners_type", "partners", ["type"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_partners_type", table_name="partners")
+    op.drop_index("ix_partners_name", table_name="partners")
+    op.drop_table("partners")
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        op.execute('DROP EXTENSION IF EXISTS "citext";')
+        op.execute('DROP EXTENSION IF EXISTS "pgcrypto";')

--- a/backend/app/api/partners.py
+++ b/backend/app/api/partners.py
@@ -1,0 +1,101 @@
+from uuid import UUID
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.deps import (
+    get_current_admin,
+    get_current_user,
+    get_db,
+    get_pagination,
+)
+from app.models.user import User
+from app.schemas.partner import (
+    PartnerCreate,
+    PartnerListResponse,
+    PartnerPublic,
+    PartnerUpdate,
+)
+from app.services.partner_service import (
+    create_partner,
+    delete_partner,
+    get_partner,
+    list_partners,
+    update_partner,
+)
+
+router = APIRouter(prefix="/partners", tags=["partners"])
+
+
+@router.get("", response_model=PartnerListResponse)
+def list_partners_endpoint(
+    pagination: tuple[int, int] = Depends(get_pagination),
+    search: str | None = None,
+    type: str | None = None,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    page, page_size = pagination
+    items, total = list_partners(db, page, page_size, search, type)
+    return {"items": items, "total": total, "page": page, "page_size": page_size}
+
+
+@router.get("/{partner_id}", response_model=PartnerPublic)
+def get_partner_endpoint(
+    partner_id: UUID,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    partner = get_partner(db, partner_id)
+    if not partner:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Partner not found")
+    return partner
+
+
+@router.post("", response_model=PartnerPublic, status_code=status.HTTP_201_CREATED)
+def create_partner_endpoint(
+    data: PartnerCreate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    try:
+        partner = create_partner(db, data)
+    except IntegrityError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Partner with this tax number already exists",
+        )
+    return partner
+
+
+@router.put("/{partner_id}", status_code=status.HTTP_204_NO_CONTENT)
+def update_partner_endpoint(
+    partner_id: UUID,
+    data: PartnerUpdate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    try:
+        partner = update_partner(db, partner_id, data)
+    except IntegrityError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Partner with this tax number already exists",
+        )
+    if not partner:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Partner not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.delete("/{partner_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_partner_endpoint(
+    partner_id: UUID,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    deleted = delete_partner(db, partner_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Partner not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -9,4 +9,5 @@ from app.models import (
     stock_movement,
     user,
     warehouse,
+    partner,
 )  # noqa: E402,F401

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from app.api.categories import router as categories_router
 from app.api.warehouses import router as warehouses_router
 from app.api.stock_movements import router as stock_movements_router
 from app.api.stock import router as stock_router
+from app.api.partners import router as partners_router
 from app.core.security import hash_password
 from app.core.config import settings
 from app.db.session import SessionLocal
@@ -38,3 +39,4 @@ app.include_router(categories_router)
 app.include_router(warehouses_router)
 app.include_router(stock_movements_router)
 app.include_router(stock_router)
+app.include_router(partners_router)

--- a/backend/app/models/partner.py
+++ b/backend/app/models/partner.py
@@ -1,0 +1,36 @@
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Column,
+    DateTime,
+    Index,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import CITEXT, UUID
+
+from app.db.base import Base
+
+
+class Partner(Base):
+    __tablename__ = "partners"
+    __table_args__ = (
+        Index("ix_partners_name", text("lower(name)")),
+        Index("ix_partners_type", "type"),
+        CheckConstraint(
+            "type IN ('customer','supplier','both')",
+            name="chk_partner_type",
+        ),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()"))
+    name = Column(Text, nullable=False)
+    type = Column(Text, nullable=False)
+    email = Column(CITEXT(), nullable=True)
+    phone = Column(Text, nullable=True)
+    tax_number = Column(Text, nullable=True, unique=True)
+    billing_address = Column(Text, nullable=True)
+    shipping_address = Column(Text, nullable=True)
+    is_active = Column(Boolean, nullable=False, server_default=text("true"))
+    created_at_utc = Column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/backend/app/schemas/partner.py
+++ b/backend/app/schemas/partner.py
@@ -1,0 +1,52 @@
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, constr
+
+from app.schemas.common import PageMeta
+
+
+class PartnerBase(BaseModel):
+    name: str = Field(..., min_length=2, max_length=120)
+    type: Literal["customer", "supplier", "both"]
+    email: EmailStr | None = None
+    phone: str | None = None
+    tax_number: constr(min_length=5, max_length=20) | None = None
+    billing_address: str | None = None
+    shipping_address: str | None = None
+    is_active: bool = True
+
+
+class PartnerCreate(PartnerBase):
+    pass
+
+
+class PartnerUpdate(BaseModel):
+    name: str | None = Field(None, min_length=2, max_length=120)
+    type: Literal["customer", "supplier", "both"] | None = None
+    email: EmailStr | None = None
+    phone: str | None = None
+    tax_number: constr(min_length=5, max_length=20) | None = None
+    billing_address: str | None = None
+    shipping_address: str | None = None
+    is_active: bool | None = None
+
+
+class PartnerPublic(BaseModel):
+    id: UUID
+    name: str
+    type: Literal["customer", "supplier", "both"]
+    email: EmailStr | None
+    phone: str | None
+    tax_number: str | None
+    billing_address: str | None
+    shipping_address: str | None
+    is_active: bool
+    created_at_utc: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PartnerListResponse(PageMeta):
+    items: list[PartnerPublic]

--- a/backend/app/services/partner_service.py
+++ b/backend/app/services/partner_service.py
@@ -1,0 +1,78 @@
+from typing import Sequence
+from uuid import UUID
+
+from sqlalchemy import or_
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.partner import Partner
+from app.schemas.partner import PartnerCreate, PartnerUpdate
+
+
+def create_partner(db: Session, data: PartnerCreate) -> Partner:
+    partner = Partner(**data.model_dump())
+    db.add(partner)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise
+    db.refresh(partner)
+    return partner
+
+
+def get_partner(db: Session, id: UUID) -> Partner | None:
+    return db.get(Partner, id)
+
+
+def list_partners(
+    db: Session,
+    page: int,
+    page_size: int,
+    search: str | None = None,
+    type: str | None = None,
+) -> tuple[Sequence[Partner], int]:
+    query = db.query(Partner)
+    if search:
+        like = f"%{search}%"
+        query = query.filter(
+            or_(
+                Partner.name.ilike(like),
+                Partner.email.ilike(like),
+                Partner.phone.ilike(like),
+            )
+        )
+    if type:
+        query = query.filter(Partner.type == type)
+    total = query.count()
+    items = (
+        query.order_by(Partner.created_at_utc.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+    return items, total
+
+
+def update_partner(db: Session, id: UUID, data: PartnerUpdate) -> Partner | None:
+    partner = db.get(Partner, id)
+    if not partner:
+        return None
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(partner, field, value)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise
+    db.refresh(partner)
+    return partner
+
+
+def delete_partner(db: Session, id: UUID) -> bool:
+    partner = db.get(Partner, id)
+    if not partner:
+        return False
+    db.delete(partner)
+    db.commit()
+    return True

--- a/backend/tests/api/test_partners.py
+++ b/backend/tests/api/test_partners.py
@@ -1,0 +1,107 @@
+from app.db.session import SessionLocal
+from app.models.partner import Partner
+
+def seed_partners():
+    db = SessionLocal()
+    partners = [
+        Partner(name="Alpha Co", type="customer", tax_number="TN1"),
+        Partner(name="Beta LLC", type="supplier", tax_number="TN2"),
+        Partner(name="Gamma Ltd", type="both", tax_number="TN3"),
+    ]
+    db.add_all(partners)
+    db.commit()
+    db.close()
+
+
+def test_admin_can_create_and_get_partner(client, admin_token):
+    payload = {"name": "Acme", "type": "customer", "tax_number": "UNQ1"}
+    res = client.post(
+        "/partners",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=payload,
+    )
+    assert res.status_code == 201
+    data = res.json()
+    part_id = data["id"]
+    assert data["tax_number"] == "UNQ1"
+
+    res_get = client.get(
+        f"/partners/{part_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert res_get.status_code == 200
+    assert res_get.json()["id"] == part_id
+
+
+def test_list_partners_pagination_search_type(client, user_token):
+    seed_partners()
+    res = client.get(
+        "/partners",
+        headers={"Authorization": f"Bearer {user_token}"},
+        params={"page": 1, "page_size": 2},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["total"] == 3
+    assert len(body["items"]) == 2
+
+    res_search = client.get(
+        "/partners",
+        headers={"Authorization": f"Bearer {user_token}"},
+        params={"search": "beta"},
+    )
+    assert res_search.status_code == 200
+    assert res_search.json()["total"] == 1
+
+    res_type = client.get(
+        "/partners",
+        headers={"Authorization": f"Bearer {user_token}"},
+        params={"type": "supplier"},
+    )
+    assert res_type.status_code == 200
+    body_type = res_type.json()
+    assert body_type["total"] == 1
+    assert body_type["items"][0]["type"] == "supplier"
+
+
+def test_user_cannot_modify_partner(client, user_token, admin_token):
+    res_create = client.post(
+        "/partners",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"name": "Tmp", "type": "customer"},
+    )
+    part_id = res_create.json()["id"]
+
+    res_post = client.post(
+        "/partners",
+        headers={"Authorization": f"Bearer {user_token}"},
+        json={"name": "X", "type": "customer"},
+    )
+    assert res_post.status_code == 403
+
+    res_put = client.put(
+        f"/partners/{part_id}",
+        headers={"Authorization": f"Bearer {user_token}"},
+        json={"phone": "123"},
+    )
+    assert res_put.status_code == 403
+
+    res_delete = client.delete(
+        f"/partners/{part_id}", headers={"Authorization": f"Bearer {user_token}"}
+    )
+    assert res_delete.status_code == 403
+
+
+def test_tax_number_conflict(client, admin_token):
+    payload = {"name": "DupCo", "type": "customer", "tax_number": "DUP1"}
+    res1 = client.post(
+        "/partners",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=payload,
+    )
+    assert res1.status_code == 201
+    res2 = client.post(
+        "/partners",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=payload,
+    )
+    assert res2.status_code == 409


### PR DESCRIPTION
## Summary
- add database migration and SQLAlchemy model for partners
- implement schemas, service layer, and REST API with search, pagination, and RBAC
- document partners CRUD examples in README

## Testing
- `pytest -q` *(fails: RuntimeError: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac166e0278832d9ef80272248571e2