### PR TITLE
feat: add sales quote flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@
      -d '{"phone":"555-0000"}'`
    `curl -s -X DELETE http://localhost:8000/partners/$PART_ID -H "Authorization: Bearer $TOKEN"`
 
+12. Satış Teklifleri örnekleri:
+   `QUOTE_PARTNER_ID=<önceden_oluşturulmuş_partner_id>`
+   `QUOTE_PROD_ID=<önceden_oluşturulmuş_urun_id>`
+   `curl -s -X POST http://localhost:8000/sales/quotes \\`
+   `  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\`
+   `  -d '{"partner_id":"'$QUOTE_PARTNER_ID'","items":[{"product_id":"'$QUOTE_PROD_ID'","quantity":1,"unit_price":100}]}'`
+   `curl -s http://localhost:8000/sales/quotes -H "Authorization: Bearer $TOKEN"`
+   `QUOTE_ID=<dönen_id>`
+   `curl -s -X POST http://localhost:8000/sales/quotes/$QUOTE_ID/status \\`
+   `  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\`
+   `  -d '{"status":"SENT"}'`
+
 > Port çakışması notu: Lokal Postgres 5432 kullanıyorsa compose dosyasında `5432:5432` yerine `5433:5432` map et.
 
 > **Not:** Uygulama Postgres gerektirir. `DATABASE_URL` "postgresql" ile başlamıyorsa `RuntimeError("PostgreSQL required; run inside docker-compose")` fırlatır.

--- a/backend/alembic/versions/0007_create_quotes.py
+++ b/backend/alembic/versions/0007_create_quotes.py
@@ -1,0 +1,81 @@
+"""create quotes tables"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0007"
+down_revision = "0006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        op.execute('CREATE EXTENSION IF NOT EXISTS "pgcrypto";')
+    op.create_table(
+        "quotes",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("number", sa.Text(), nullable=False, unique=True),
+        sa.Column("partner_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("currency", sa.Text(), nullable=False, server_default="TRY"),
+        sa.Column("status", sa.Text(), nullable=False, server_default="DRAFT"),
+        sa.Column("issue_date", sa.Date(), nullable=False, server_default=sa.func.current_date()),
+        sa.Column("valid_until", sa.Date(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("discount_rate", sa.Numeric(5, 2), nullable=False, server_default="0.00"),
+        sa.Column("subtotal", sa.Numeric(14, 2), nullable=False, server_default="0.00"),
+        sa.Column("tax_total", sa.Numeric(14, 2), nullable=False, server_default="0.00"),
+        sa.Column("grand_total", sa.Numeric(14, 2), nullable=False, server_default="0.00"),
+        sa.Column("created_at_utc", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["partner_id"], ["partners.id"], ondelete="RESTRICT"),
+        sa.CheckConstraint(
+            "status IN ('DRAFT','SENT','APPROVED','REJECTED','EXPIRED')",
+            name="chk_quote_status",
+        ),
+        sa.CheckConstraint(
+            "discount_rate >= 0 AND discount_rate <= 100",
+            name="chk_quote_discount_rate",
+        ),
+    )
+    op.create_table(
+        "quote_items",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("quote_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("product_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("quantity", sa.Numeric(14, 3), nullable=False),
+        sa.Column("unit_price", sa.Numeric(14, 2), nullable=False),
+        sa.Column("line_discount_rate", sa.Numeric(5, 2), nullable=False, server_default="0.00"),
+        sa.Column("tax_rate", sa.Numeric(5, 2), nullable=False, server_default="20.00"),
+        sa.Column("line_subtotal", sa.Numeric(14, 2), nullable=False, server_default="0.00"),
+        sa.Column("line_tax", sa.Numeric(14, 2), nullable=False, server_default="0.00"),
+        sa.Column("line_total", sa.Numeric(14, 2), nullable=False, server_default="0.00"),
+        sa.ForeignKeyConstraint(["quote_id"], ["quotes.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["product_id"], ["products.id"], ondelete="RESTRICT"),
+        sa.CheckConstraint("quantity > 0", name="chk_quote_item_quantity_positive"),
+        sa.CheckConstraint("unit_price >= 0", name="chk_quote_item_unit_price_nonneg"),
+        sa.CheckConstraint(
+            "line_discount_rate >= 0 AND line_discount_rate <= 100",
+            name="chk_quote_item_discount_rate",
+        ),
+        sa.CheckConstraint(
+            "tax_rate >= 0 AND tax_rate <= 100",
+            name="chk_quote_item_tax_rate",
+        ),
+    )
+    op.create_index("ix_quotes_partner", "quotes", ["partner_id"])
+    op.create_index("ix_quotes_created", "quotes", [sa.text("created_at_utc DESC")])
+    op.create_index("ix_quote_items_quote", "quote_items", ["quote_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_quote_items_quote", table_name="quote_items")
+    op.drop_table("quote_items")
+    op.drop_index("ix_quotes_created", table_name="quotes")
+    op.drop_index("ix_quotes_partner", table_name="quotes")
+    op.drop_table("quotes")
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        op.execute('DROP EXTENSION IF EXISTS "pgcrypto";')

--- a/backend/app/api/quotes.py
+++ b/backend/app/api/quotes.py
@@ -1,0 +1,97 @@
+from uuid import UUID
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from pydantic import BaseModel
+
+from app.core.deps import (
+    get_current_admin,
+    get_current_user,
+    get_db,
+    get_pagination,
+)
+from app.models.user import User
+from app.schemas.quote import QuoteCreate, QuoteListResponse, QuotePublic, QuoteUpdate
+from app.services.quote_service import (
+    create_quote,
+    get_quote,
+    list_quotes,
+    set_status,
+    update_quote,
+)
+
+
+class StatusChange(BaseModel):
+    status: Literal["SENT", "APPROVED", "REJECTED", "EXPIRED"]
+
+
+router = APIRouter(prefix="/sales/quotes", tags=["sales-quotes"])
+
+
+@router.get("", response_model=QuoteListResponse)
+def list_quotes_endpoint(
+    pagination: tuple[int, int] = Depends(get_pagination),
+    search: str | None = None,
+    status: str | None = None,
+    partner_id: UUID | None = None,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    page, page_size = pagination
+    items, total = list_quotes(db, page, page_size, search, status, partner_id)
+    return {"items": items, "total": total, "page": page, "page_size": page_size}
+
+
+@router.get("/{quote_id}", response_model=QuotePublic)
+def get_quote_endpoint(
+    quote_id: UUID,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    quote = get_quote(db, quote_id)
+    if not quote:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quote not found")
+    return quote
+
+
+@router.post("", response_model=QuotePublic, status_code=status.HTTP_201_CREATED)
+def create_quote_endpoint(
+    data: QuoteCreate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    quote = create_quote(db, data)
+    return quote
+
+
+@router.put("/{quote_id}", response_model=QuotePublic)
+def update_quote_endpoint(
+    quote_id: UUID,
+    data: QuoteUpdate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    try:
+        quote = update_quote(db, quote_id, data)
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="immutable_state")
+    if not quote:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quote not found")
+    return quote
+
+
+@router.post("/{quote_id}/status", response_model=QuotePublic)
+def change_status_endpoint(
+    quote_id: UUID,
+    body: StatusChange,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    try:
+        quote = set_status(db, quote_id, body.status)
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="invalid_status")
+    if not quote:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quote not found")
+    return quote

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -10,4 +10,5 @@ from app.models import (
     user,
     warehouse,
     partner,
+    quote,
 )  # noqa: E402,F401

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from app.api.warehouses import router as warehouses_router
 from app.api.stock_movements import router as stock_movements_router
 from app.api.stock import router as stock_router
 from app.api.partners import router as partners_router
+from app.api.quotes import router as quotes_router
 from app.core.security import hash_password
 from app.core.config import settings
 from app.db.session import SessionLocal
@@ -40,3 +41,4 @@ app.include_router(warehouses_router)
 app.include_router(stock_movements_router)
 app.include_router(stock_router)
 app.include_router(partners_router)
+app.include_router(quotes_router)

--- a/backend/app/models/quote.py
+++ b/backend/app/models/quote.py
@@ -1,0 +1,100 @@
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    Numeric,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from app.db.base import Base
+
+
+class Quote(Base):
+    __tablename__ = "quotes"
+    __table_args__ = (
+        Index("ix_quotes_partner", "partner_id"),
+        Index("ix_quotes_created", text("created_at_utc DESC")),
+        CheckConstraint(
+            "status IN ('DRAFT','SENT','APPROVED','REJECTED','EXPIRED')",
+            name="chk_quote_status",
+        ),
+        CheckConstraint(
+            "discount_rate >= 0 AND discount_rate <= 100",
+            name="chk_quote_discount_rate",
+        ),
+    )
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    number = Column(Text, nullable=False, unique=True)
+    partner_id = Column(
+        UUID(as_uuid=True), ForeignKey("partners.id", ondelete="RESTRICT"), nullable=False
+    )
+    currency = Column(Text, nullable=False, server_default=text("'TRY'"))
+    status = Column(Text, nullable=False, server_default=text("'DRAFT'"))
+    issue_date = Column(Date, nullable=False, server_default=func.current_date())
+    valid_until = Column(Date, nullable=True)
+    notes = Column(Text, nullable=True)
+    discount_rate = Column(Numeric(5, 2), nullable=False, server_default=text("0.00"))
+    subtotal = Column(Numeric(14, 2), nullable=False, server_default=text("0.00"))
+    tax_total = Column(Numeric(14, 2), nullable=False, server_default=text("0.00"))
+    grand_total = Column(Numeric(14, 2), nullable=False, server_default=text("0.00"))
+    created_at_utc = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    items = relationship(
+        "QuoteItem",
+        back_populates="quote",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
+
+class QuoteItem(Base):
+    __tablename__ = "quote_items"
+    __table_args__ = (
+        Index("ix_quote_items_quote", "quote_id"),
+        CheckConstraint("quantity > 0", name="chk_quote_item_quantity_positive"),
+        CheckConstraint("unit_price >= 0", name="chk_quote_item_unit_price_nonneg"),
+        CheckConstraint(
+            "line_discount_rate >= 0 AND line_discount_rate <= 100",
+            name="chk_quote_item_discount_rate",
+        ),
+        CheckConstraint(
+            "tax_rate >= 0 AND tax_rate <= 100",
+            name="chk_quote_item_tax_rate",
+        ),
+    )
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    quote_id = Column(
+        UUID(as_uuid=True), ForeignKey("quotes.id", ondelete="CASCADE"), nullable=False
+    )
+    product_id = Column(
+        UUID(as_uuid=True), ForeignKey("products.id", ondelete="RESTRICT"), nullable=False
+    )
+    description = Column(Text, nullable=True)
+    quantity = Column(Numeric(14, 3), nullable=False)
+    unit_price = Column(Numeric(14, 2), nullable=False)
+    line_discount_rate = Column(Numeric(5, 2), nullable=False, server_default=text("0.00"))
+    tax_rate = Column(Numeric(5, 2), nullable=False, server_default=text("20.00"))
+    line_subtotal = Column(Numeric(14, 2), nullable=False, server_default=text("0.00"))
+    line_tax = Column(Numeric(14, 2), nullable=False, server_default=text("0.00"))
+    line_total = Column(Numeric(14, 2), nullable=False, server_default=text("0.00"))
+
+    quote = relationship("Quote", back_populates="items")

--- a/backend/app/schemas/quote.py
+++ b/backend/app/schemas/quote.py
@@ -1,0 +1,89 @@
+from datetime import date, datetime
+from decimal import Decimal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.schemas.common import PageMeta
+
+
+class QuoteItemIn(BaseModel):
+    product_id: UUID
+    description: str | None = None
+    quantity: Decimal = Field(..., gt=0)
+    unit_price: Decimal = Field(..., ge=0)
+    line_discount_rate: Decimal = Field(0, ge=0, le=100)
+    tax_rate: Decimal = Field(20, ge=0, le=100)
+
+
+class QuoteItemPublic(QuoteItemIn):
+    line_subtotal: Decimal
+    line_tax: Decimal
+    line_total: Decimal
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class QuoteCreate(BaseModel):
+    partner_id: UUID
+    currency: str = "TRY"
+    issue_date: date | None = None
+    valid_until: date | None = None
+    notes: str | None = None
+    discount_rate: Decimal = Field(0, ge=0, le=100)
+    items: list[QuoteItemIn] = Field(..., min_length=1)
+
+    @field_validator("items")
+    @classmethod
+    def check_items(cls, v):
+        if not v:
+            raise ValueError("at least one item required")
+        return v
+
+
+class QuoteUpdate(BaseModel):
+    notes: str | None = None
+    discount_rate: Decimal | None = Field(None, ge=0, le=100)
+    valid_until: date | None = None
+    items: list[QuoteItemIn] | None = Field(None, min_length=1)
+
+
+class QuotePublic(BaseModel):
+    id: UUID
+    number: str
+    partner_id: UUID
+    currency: str
+    status: str
+    issue_date: date
+    valid_until: date | None
+    notes: str | None
+    discount_rate: Decimal
+    subtotal: Decimal
+    tax_total: Decimal
+    grand_total: Decimal
+    created_at_utc: datetime
+    items: list[QuoteItemPublic]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class QuoteSummary(BaseModel):
+    id: UUID
+    number: str
+    partner_id: UUID
+    currency: str
+    status: str
+    issue_date: date
+    valid_until: date | None
+    notes: str | None
+    discount_rate: Decimal
+    subtotal: Decimal
+    tax_total: Decimal
+    grand_total: Decimal
+    created_at_utc: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class QuoteListResponse(PageMeta):
+    items: list[QuoteSummary]

--- a/backend/app/services/quote_service.py
+++ b/backend/app/services/quote_service.py
@@ -1,0 +1,153 @@
+from datetime import date
+from decimal import Decimal
+from typing import Sequence
+from uuid import UUID
+
+from sqlalchemy.orm import Session, selectinload
+
+from app.models.quote import Quote, QuoteItem
+from app.schemas.quote import QuoteCreate, QuoteUpdate, QuoteItemIn
+
+
+def _generate_number(db: Session, issue_date: date) -> str:
+    year = issue_date.year
+    like = f"Q-{year}-%"
+    last = (
+        db.query(Quote.number)
+        .filter(Quote.number.like(like))
+        .order_by(Quote.number.desc())
+        .first()
+    )
+    if last:
+        seq = int(last[0].split("-")[-1]) + 1
+    else:
+        seq = 1
+    return f"Q-{year}-{seq:05d}"
+
+
+def _calc_item(data: QuoteItemIn) -> QuoteItem:
+    q = data.quantity
+    price = data.unit_price
+    disc = data.line_discount_rate / Decimal("100")
+    tax_rate = data.tax_rate / Decimal("100")
+    line_subtotal = q * price * (Decimal("1") - disc)
+    line_tax = line_subtotal * tax_rate
+    line_total = line_subtotal + line_tax
+    return QuoteItem(
+        product_id=data.product_id,
+        description=data.description,
+        quantity=q,
+        unit_price=price,
+        line_discount_rate=data.line_discount_rate,
+        tax_rate=data.tax_rate,
+        line_subtotal=line_subtotal,
+        line_tax=line_tax,
+        line_total=line_total,
+    )
+
+
+def _recalc_totals(quote: Quote) -> None:
+    subtotal = sum((item.line_subtotal for item in quote.items), Decimal("0"))
+    tax_total = sum((item.line_tax for item in quote.items), Decimal("0"))
+    subtotal_after = subtotal * (Decimal("1") - quote.discount_rate / Decimal("100"))
+    quote.subtotal = subtotal_after
+    quote.tax_total = tax_total
+    quote.grand_total = subtotal_after + tax_total
+
+
+def create_quote(db: Session, data: QuoteCreate) -> Quote:
+    issue_date = data.issue_date or date.today()
+    number = _generate_number(db, issue_date)
+    quote = Quote(
+        number=number,
+        partner_id=data.partner_id,
+        currency=data.currency,
+        issue_date=issue_date,
+        valid_until=data.valid_until,
+        notes=data.notes,
+        discount_rate=data.discount_rate,
+    )
+    for item_in in data.items:
+        quote.items.append(_calc_item(item_in))
+    _recalc_totals(quote)
+    db.add(quote)
+    db.commit()
+    db.refresh(quote)
+    return quote
+
+
+def get_quote(db: Session, id: UUID) -> Quote | None:
+    return (
+        db.query(Quote)
+        .options(selectinload(Quote.items))
+        .filter(Quote.id == id)
+        .first()
+    )
+
+
+def list_quotes(
+    db: Session,
+    page: int,
+    page_size: int,
+    search: str | None = None,
+    status: str | None = None,
+    partner_id: UUID | None = None,
+) -> tuple[Sequence[Quote], int]:
+    query = db.query(Quote)
+    if search:
+        like = f"%{search}%"
+        query = query.filter(Quote.number.ilike(like))
+    if status:
+        query = query.filter(Quote.status == status)
+    if partner_id:
+        query = query.filter(Quote.partner_id == partner_id)
+    total = query.count()
+    items = (
+        query.order_by(Quote.created_at_utc.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+    return items, total
+
+
+def update_quote(db: Session, id: UUID, data: QuoteUpdate) -> Quote | None:
+    quote = db.query(Quote).options(selectinload(Quote.items)).get(id)
+    if not quote:
+        return None
+    if quote.status != "DRAFT":
+        raise ValueError("immutable_state")
+    if data.notes is not None:
+        quote.notes = data.notes
+    if data.discount_rate is not None:
+        quote.discount_rate = data.discount_rate
+    if data.valid_until is not None:
+        quote.valid_until = data.valid_until
+    if data.items is not None:
+        quote.items.clear()
+        for item_in in data.items:
+            quote.items.append(_calc_item(item_in))
+    _recalc_totals(quote)
+    db.commit()
+    db.refresh(quote)
+    return quote
+
+
+def set_status(db: Session, id: UUID, new_status: str) -> Quote | None:
+    quote = db.get(Quote, id)
+    if not quote:
+        return None
+    transitions = {
+        "DRAFT": {"SENT", "APPROVED", "REJECTED"},
+        "SENT": {"APPROVED", "REJECTED", "EXPIRED"},
+        "APPROVED": set(),
+        "REJECTED": set(),
+        "EXPIRED": set(),
+    }
+    allowed = transitions.get(quote.status, set())
+    if new_status not in allowed:
+        raise ValueError("invalid_status")
+    quote.status = new_status
+    db.commit()
+    db.refresh(quote)
+    return quote

--- a/backend/tests/api/test_quotes.py
+++ b/backend/tests/api/test_quotes.py
@@ -1,0 +1,165 @@
+from uuid import uuid4
+
+from app.db.session import SessionLocal
+from app.models.partner import Partner
+from app.models.product import Product
+
+
+def seed_partner_and_product():
+    db = SessionLocal()
+    partner = Partner(id=uuid4(), name="Cust", type="customer")
+    product = Product(id=uuid4(), name="Widget", sku=str(uuid4())[:8], price=100)
+    db.add_all([partner, product])
+    db.commit()
+    db.refresh(partner)
+    db.refresh(product)
+    db.close()
+    return partner, product
+
+
+def test_admin_create_quote_and_totals(client, admin_token, user_token):
+    partner, product = seed_partner_and_product()
+    payload = {
+        "partner_id": str(partner.id),
+        "items": [
+            {
+                "product_id": str(product.id),
+                "quantity": 2,
+                "unit_price": 100,
+                "line_discount_rate": 10,
+                "tax_rate": 20,
+            }
+        ],
+    }
+    res = client.post(
+        "/sales/quotes",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=payload,
+    )
+    assert res.status_code == 201
+    data = res.json()
+    assert data["status"] == "DRAFT"
+    assert float(data["grand_total"]) == 216.0
+
+    res_forbidden = client.post(
+        "/sales/quotes",
+        headers={"Authorization": f"Bearer {user_token}"},
+        json=payload,
+    )
+    assert res_forbidden.status_code == 403
+
+
+def test_status_transitions(client, admin_token):
+    partner, product = seed_partner_and_product()
+    payload = {
+        "partner_id": str(partner.id),
+        "items": [
+            {
+                "product_id": str(product.id),
+                "quantity": 1,
+                "unit_price": 50,
+            }
+        ],
+    }
+    res = client.post(
+        "/sales/quotes",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=payload,
+    )
+    quote_id = res.json()["id"]
+
+    bad = client.post(
+        f"/sales/quotes/{quote_id}/status",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"status": "EXPIRED"},
+    )
+    assert bad.status_code == 409
+
+    sent = client.post(
+        f"/sales/quotes/{quote_id}/status",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"status": "SENT"},
+    )
+    assert sent.status_code == 200
+    assert sent.json()["status"] == "SENT"
+
+    approved = client.post(
+        f"/sales/quotes/{quote_id}/status",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"status": "APPROVED"},
+    )
+    assert approved.status_code == 200
+    assert approved.json()["status"] == "APPROVED"
+
+    again = client.post(
+        f"/sales/quotes/{quote_id}/status",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"status": "REJECTED"},
+    )
+    assert again.status_code == 409
+
+
+def test_list_search_status_filters(client, admin_token, user_token):
+    partner1, product = seed_partner_and_product()
+    db = SessionLocal()
+    partner2 = Partner(id=uuid4(), name="Beta", type="customer")
+    db.add(partner2)
+    db.commit()
+    db.refresh(partner2)
+    db.close()
+
+    def create_quote(p_id):
+        res = client.post(
+            "/sales/quotes",
+            headers={"Authorization": f"Bearer {admin_token}"},
+            json={
+                "partner_id": str(p_id),
+                "items": [{"product_id": str(product.id), "quantity": 1, "unit_price": 10}],
+            },
+        )
+        return res.json()
+
+    q1 = create_quote(partner1.id)
+    q2 = create_quote(partner1.id)
+    client.post(
+        f"/sales/quotes/{q2['id']}/status",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"status": "SENT"},
+    )
+    q3 = create_quote(partner2.id)
+    client.post(
+        f"/sales/quotes/{q3['id']}/status",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"status": "APPROVED"},
+    )
+
+    res_all = client.get(
+        "/sales/quotes",
+        headers={"Authorization": f"Bearer {user_token}"},
+    )
+    assert res_all.status_code == 200
+    assert res_all.json()["total"] == 3
+
+    res_status = client.get(
+        "/sales/quotes",
+        headers={"Authorization": f"Bearer {user_token}"},
+        params={"status": "APPROVED"},
+    )
+    assert res_status.status_code == 200
+    assert res_status.json()["total"] == 1
+
+    res_partner = client.get(
+        "/sales/quotes",
+        headers={"Authorization": f"Bearer {user_token}"},
+        params={"partner_id": str(partner1.id)},
+    )
+    assert res_partner.status_code == 200
+    assert res_partner.json()["total"] == 2
+
+    res_search = client.get(
+        "/sales/quotes",
+        headers={"Authorization": f"Bearer {user_token}"},
+        params={"search": q1["number"]},
+    )
+    assert res_search.status_code == 200
+    assert res_search.json()["total"] == 1


### PR DESCRIPTION
## Summary
- add quotes and quote_items tables with SQLAlchemy models and migrations
- implement quote schemas, service, and API router with RBAC and status logic
- document quote endpoints and add tests for totals, transitions, filters

## Testing
- `pytest -q` *(fails: The starlette.testclient module requires the httpx package to be installed)*
- `pip install httpx -q` *(fails: Could not find a version that satisfies the requirement httpx due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68ac198de380832d9f7abe18425d9a12