### PR TITLE
Add sales invoice module with RBAC and totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@
    `curl -s -X POST http://localhost:8000/sales/orders/$ORDER_ID/status \`
    `  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \`
    `  -d '{"status":"FULFILLED"}'`
+14. Satış Faturaları örnekleri:
+   `INV_PARTNER_ID=<önceden_oluşturulmuş_partner_id>`
+   `INV_PROD_ID=<önceden_oluşturulmuş_urun_id>`
+   `curl -s -X POST http://localhost:8000/sales/invoices \\
+     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\
+     -d '{"partner_id":"'$INV_PARTNER_ID'","items":[{"product_id":"'$INV_PROD_ID'","quantity":1,"unit_price":100}]}'`
+   `curl -s http://localhost:8000/sales/invoices -H "Authorization: Bearer $TOKEN"`
+   `INV_ID=<dönen_id>`
+   `curl -s -X POST http://localhost:8000/sales/invoices/$INV_ID/status \\
+     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\
+     -d '{"status":"ISSUED"}'`
 
 > Port çakışması notu: Lokal Postgres 5432 kullanıyorsa compose dosyasında `5432:5432` yerine `5433:5432` map et.
 

--- a/backend/alembic/versions/0009_create_sales_invoices.py
+++ b/backend/alembic/versions/0009_create_sales_invoices.py
@@ -1,0 +1,90 @@
+"""create sales invoices tables"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        op.execute('CREATE EXTENSION IF NOT EXISTS "pgcrypto";')
+    op.create_table(
+        "sales_invoices",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("number", sa.Text(), nullable=False, unique=True),
+        sa.Column("partner_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("order_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("currency", sa.Text(), nullable=False, server_default="TRY"),
+        sa.Column("status", sa.Text(), nullable=False, server_default="DRAFT"),
+        sa.Column("issue_date", sa.Date(), nullable=False, server_default=sa.func.current_date()),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("discount_rate", sa.Numeric(5, 2), nullable=False, server_default="0.00"),
+        sa.Column("subtotal", sa.Numeric(14, 2), nullable=False, server_default="0.00"),
+        sa.Column("tax_total", sa.Numeric(14, 2), nullable=False, server_default="0.00"),
+        sa.Column("grand_total", sa.Numeric(14, 2), nullable=False, server_default="0.00"),
+        sa.Column("created_at_utc", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["partner_id"], ["partners.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["order_id"], ["sales_orders.id"], ondelete="SET NULL"),
+        sa.CheckConstraint(
+            "status IN ('DRAFT','ISSUED','PAID','CANCELLED')",
+            name="chk_sales_invoice_status",
+        ),
+        sa.CheckConstraint(
+            "discount_rate >= 0 AND discount_rate <= 100",
+            name="chk_sales_invoice_discount_rate",
+        ),
+    )
+    op.create_table(
+        "sales_invoice_items",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("invoice_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("product_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("quantity", sa.Numeric(14, 3), nullable=False),
+        sa.Column("unit_price", sa.Numeric(14, 2), nullable=False),
+        sa.Column("line_discount_rate", sa.Numeric(5, 2), nullable=False, server_default="0.00"),
+        sa.Column("tax_rate", sa.Numeric(5, 2), nullable=False, server_default="20.00"),
+        sa.Column("line_subtotal", sa.Numeric(14, 2), nullable=False, server_default="0.00"),
+        sa.Column("line_tax", sa.Numeric(14, 2), nullable=False, server_default="0.00"),
+        sa.Column("line_total", sa.Numeric(14, 2), nullable=False, server_default="0.00"),
+        sa.ForeignKeyConstraint(["invoice_id"], ["sales_invoices.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["product_id"], ["products.id"], ondelete="RESTRICT"),
+        sa.CheckConstraint("quantity > 0", name="chk_sales_invoice_item_quantity_positive"),
+        sa.CheckConstraint(
+            "unit_price >= 0", name="chk_sales_invoice_item_unit_price_nonneg"
+        ),
+        sa.CheckConstraint(
+            "line_discount_rate >= 0 AND line_discount_rate <= 100",
+            name="chk_sales_invoice_item_discount_rate",
+        ),
+        sa.CheckConstraint(
+            "tax_rate >= 0 AND tax_rate <= 100",
+            name="chk_sales_invoice_item_tax_rate",
+        ),
+    )
+    op.create_index("ix_sales_invoices_partner", "sales_invoices", ["partner_id"])
+    op.create_index(
+        "ix_sales_invoices_created", "sales_invoices", [sa.text("created_at_utc DESC")]
+    )
+    op.create_index(
+        "ix_sales_invoice_items_invoice", "sales_invoice_items", ["invoice_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_sales_invoice_items_invoice", table_name="sales_invoice_items"
+    )
+    op.drop_table("sales_invoice_items")
+    op.drop_index("ix_sales_invoices_created", table_name="sales_invoices")
+    op.drop_index("ix_sales_invoices_partner", table_name="sales_invoices")
+    op.drop_table("sales_invoices")
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        op.execute('DROP EXTENSION IF EXISTS "pgcrypto";')

--- a/backend/app/api/sales_invoices.py
+++ b/backend/app/api/sales_invoices.py
@@ -1,0 +1,110 @@
+from typing import Literal
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.core.deps import (
+    get_current_admin,
+    get_current_user,
+    get_db,
+    get_pagination,
+)
+from app.models.user import User
+from app.schemas.sales_invoice import (
+    SalesInvoiceCreate,
+    SalesInvoiceListResponse,
+    SalesInvoicePublic,
+    SalesInvoiceUpdate,
+)
+from app.services.sales_invoice_service import (
+    create_invoice,
+    get_invoice,
+    list_invoices,
+    set_status,
+    update_invoice,
+)
+
+
+class StatusChange(BaseModel):
+    status: Literal["ISSUED", "PAID", "CANCELLED"]
+
+
+router = APIRouter(prefix="/sales/invoices", tags=["sales-invoices"])
+
+
+@router.get("", response_model=SalesInvoiceListResponse)
+def list_invoices_endpoint(
+    pagination: tuple[int, int] = Depends(get_pagination),
+    search: str | None = None,
+    status: str | None = None,
+    partner_id: UUID | None = None,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    page, page_size = pagination
+    items, total = list_invoices(db, page, page_size, search, status, partner_id)
+    return {"items": items, "total": total, "page": page, "page_size": page_size}
+
+
+@router.get("/{invoice_id}", response_model=SalesInvoicePublic)
+def get_invoice_endpoint(
+    invoice_id: UUID,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    invoice = get_invoice(db, invoice_id)
+    if not invoice:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invoice not found")
+    return invoice
+
+
+@router.post("", response_model=SalesInvoicePublic, status_code=status.HTTP_201_CREATED)
+def create_invoice_endpoint(
+    data: SalesInvoiceCreate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    try:
+        invoice = create_invoice(db, data)
+    except ValueError as e:
+        detail = str(e)
+        if detail == "partner_mismatch":
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="partner_mismatch")
+        if detail == "order_not_found":
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="order_not_found")
+        raise
+    return invoice
+
+
+@router.put("/{invoice_id}", response_model=SalesInvoicePublic)
+def update_invoice_endpoint(
+    invoice_id: UUID,
+    data: SalesInvoiceUpdate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    try:
+        invoice = update_invoice(db, invoice_id, data)
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="immutable_state")
+    if not invoice:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invoice not found")
+    return invoice
+
+
+@router.post("/{invoice_id}/status", response_model=SalesInvoicePublic)
+def change_status_endpoint(
+    invoice_id: UUID,
+    body: StatusChange,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    try:
+        invoice = set_status(db, invoice_id, body.status)
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="invalid_status")
+    if not invoice:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invoice not found")
+    return invoice

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,6 +11,7 @@ from app.api.stock import router as stock_router
 from app.api.partners import router as partners_router
 from app.api.quotes import router as quotes_router
 from app.api.sales_orders import router as sales_orders_router
+from app.api.sales_invoices import router as sales_invoices_router
 from app.core.security import hash_password
 from app.core.config import settings
 from app.db.session import SessionLocal
@@ -44,3 +45,4 @@ app.include_router(stock_router)
 app.include_router(partners_router)
 app.include_router(quotes_router)
 app.include_router(sales_orders_router)
+app.include_router(sales_invoices_router)

--- a/backend/app/models/sales_invoice.py
+++ b/backend/app/models/sales_invoice.py
@@ -1,0 +1,104 @@
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    Numeric,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from app.db.base import Base
+
+
+class SalesInvoice(Base):
+    __tablename__ = "sales_invoices"
+    __table_args__ = (
+        Index("ix_sales_invoices_partner", "partner_id"),
+        Index("ix_sales_invoices_created", text("created_at_utc DESC")),
+        CheckConstraint(
+            "status IN ('DRAFT','ISSUED','PAID','CANCELLED')",
+            name="chk_sales_invoice_status",
+        ),
+        CheckConstraint(
+            "discount_rate >= 0 AND discount_rate <= 100",
+            name="chk_sales_invoice_discount_rate",
+        ),
+    )
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    number = Column(Text, nullable=False, unique=True)
+    partner_id = Column(
+        UUID(as_uuid=True), ForeignKey("partners.id", ondelete="RESTRICT"), nullable=False
+    )
+    order_id = Column(
+        UUID(as_uuid=True), ForeignKey("sales_orders.id", ondelete="SET NULL"), nullable=True
+    )
+    currency = Column(Text, nullable=False, server_default=text("'TRY'"))
+    status = Column(Text, nullable=False, server_default=text("'DRAFT'"))
+    issue_date = Column(Date, nullable=False, server_default=func.current_date())
+    notes = Column(Text, nullable=True)
+    discount_rate = Column(Numeric(5, 2), nullable=False, server_default=text("0.00"))
+    subtotal = Column(Numeric(14, 2), nullable=False, server_default=text("0.00"))
+    tax_total = Column(Numeric(14, 2), nullable=False, server_default=text("0.00"))
+    grand_total = Column(Numeric(14, 2), nullable=False, server_default=text("0.00"))
+    created_at_utc = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    items = relationship(
+        "SalesInvoiceItem",
+        back_populates="invoice",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
+
+class SalesInvoiceItem(Base):
+    __tablename__ = "sales_invoice_items"
+    __table_args__ = (
+        Index("ix_sales_invoice_items_invoice", "invoice_id"),
+        CheckConstraint("quantity > 0", name="chk_sales_invoice_item_quantity_positive"),
+        CheckConstraint(
+            "unit_price >= 0", name="chk_sales_invoice_item_unit_price_nonneg"
+        ),
+        CheckConstraint(
+            "line_discount_rate >= 0 AND line_discount_rate <= 100",
+            name="chk_sales_invoice_item_discount_rate",
+        ),
+        CheckConstraint(
+            "tax_rate >= 0 AND tax_rate <= 100",
+            name="chk_sales_invoice_item_tax_rate",
+        ),
+    )
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    invoice_id = Column(
+        UUID(as_uuid=True), ForeignKey("sales_invoices.id", ondelete="CASCADE"), nullable=False
+    )
+    product_id = Column(
+        UUID(as_uuid=True), ForeignKey("products.id", ondelete="RESTRICT"), nullable=False
+    )
+    description = Column(Text, nullable=True)
+    quantity = Column(Numeric(14, 3), nullable=False)
+    unit_price = Column(Numeric(14, 2), nullable=False)
+    line_discount_rate = Column(Numeric(5, 2), nullable=False, server_default=text("0.00"))
+    tax_rate = Column(Numeric(5, 2), nullable=False, server_default=text("20.00"))
+    line_subtotal = Column(Numeric(14, 2), nullable=False, server_default=text("0.00"))
+    line_tax = Column(Numeric(14, 2), nullable=False, server_default=text("0.00"))
+    line_total = Column(Numeric(14, 2), nullable=False, server_default=text("0.00"))
+
+    invoice = relationship("SalesInvoice", back_populates="items")

--- a/backend/app/schemas/sales_invoice.py
+++ b/backend/app/schemas/sales_invoice.py
@@ -1,0 +1,88 @@
+from datetime import date, datetime
+from decimal import Decimal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.schemas.common import PageMeta
+
+
+class SalesInvoiceItemIn(BaseModel):
+    product_id: UUID
+    description: str | None = None
+    quantity: Decimal = Field(..., gt=0)
+    unit_price: Decimal = Field(..., ge=0)
+    line_discount_rate: Decimal = Field(0, ge=0, le=100)
+    tax_rate: Decimal = Field(20, ge=0, le=100)
+
+
+class SalesInvoiceItemPublic(SalesInvoiceItemIn):
+    line_subtotal: Decimal
+    line_tax: Decimal
+    line_total: Decimal
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SalesInvoiceCreate(BaseModel):
+    partner_id: UUID
+    order_id: UUID | None = None
+    currency: str = "TRY"
+    issue_date: date | None = None
+    notes: str | None = None
+    discount_rate: Decimal = Field(0, ge=0, le=100)
+    items: list[SalesInvoiceItemIn] = Field(..., min_length=1)
+
+    @field_validator("items")
+    @classmethod
+    def check_items(cls, v):
+        if not v:
+            raise ValueError("at least one item required")
+        return v
+
+
+class SalesInvoiceUpdate(BaseModel):
+    notes: str | None = None
+    discount_rate: Decimal | None = Field(None, ge=0, le=100)
+    items: list[SalesInvoiceItemIn] | None = Field(None, min_length=1)
+
+
+class SalesInvoicePublic(BaseModel):
+    id: UUID
+    number: str
+    partner_id: UUID
+    order_id: UUID | None
+    currency: str
+    status: str
+    issue_date: date
+    notes: str | None
+    discount_rate: Decimal
+    subtotal: Decimal
+    tax_total: Decimal
+    grand_total: Decimal
+    created_at_utc: datetime
+    items: list[SalesInvoiceItemPublic]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SalesInvoiceSummary(BaseModel):
+    id: UUID
+    number: str
+    partner_id: UUID
+    order_id: UUID | None
+    currency: str
+    status: str
+    issue_date: date
+    notes: str | None
+    discount_rate: Decimal
+    subtotal: Decimal
+    tax_total: Decimal
+    grand_total: Decimal
+    created_at_utc: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SalesInvoiceListResponse(PageMeta):
+    items: list[SalesInvoiceSummary]

--- a/backend/app/services/sales_invoice_service.py
+++ b/backend/app/services/sales_invoice_service.py
@@ -1,0 +1,160 @@
+from datetime import date
+from decimal import Decimal
+from typing import Sequence
+from uuid import UUID
+
+from sqlalchemy.orm import Session, selectinload
+
+from app.models.sales_invoice import SalesInvoice, SalesInvoiceItem
+from app.models.sales_order import SalesOrder
+from app.schemas.sales_invoice import (
+    SalesInvoiceCreate,
+    SalesInvoiceItemIn,
+    SalesInvoiceUpdate,
+)
+
+
+def _generate_number(db: Session, issue_date: date) -> str:
+    year = issue_date.year
+    like = f"I-{year}-%"
+    last = (
+        db.query(SalesInvoice.number)
+        .filter(SalesInvoice.number.like(like))
+        .order_by(SalesInvoice.number.desc())
+        .first()
+    )
+    seq = int(last[0].split("-")[-1]) + 1 if last else 1
+    return f"I-{year}-{seq:05d}"
+
+
+def _calc_item(data: SalesInvoiceItemIn) -> SalesInvoiceItem:
+    q = data.quantity
+    price = data.unit_price
+    disc = data.line_discount_rate / Decimal("100")
+    tax_rate = data.tax_rate / Decimal("100")
+    line_subtotal = q * price * (Decimal("1") - disc)
+    line_tax = line_subtotal * tax_rate
+    line_total = line_subtotal + line_tax
+    return SalesInvoiceItem(
+        product_id=data.product_id,
+        description=data.description,
+        quantity=q,
+        unit_price=price,
+        line_discount_rate=data.line_discount_rate,
+        tax_rate=data.tax_rate,
+        line_subtotal=line_subtotal,
+        line_tax=line_tax,
+        line_total=line_total,
+    )
+
+
+def _recalc_totals(invoice: SalesInvoice) -> None:
+    subtotal = sum((item.line_subtotal for item in invoice.items), Decimal("0"))
+    tax_total = sum((item.line_tax for item in invoice.items), Decimal("0"))
+    subtotal_after = subtotal * (Decimal("1") - invoice.discount_rate / Decimal("100"))
+    invoice.subtotal = subtotal_after
+    invoice.tax_total = tax_total
+    invoice.grand_total = subtotal_after + tax_total
+
+
+def create_invoice(db: Session, data: SalesInvoiceCreate) -> SalesInvoice:
+    issue_date = data.issue_date or date.today()
+    number = _generate_number(db, issue_date)
+    if data.order_id:
+        order = db.get(SalesOrder, data.order_id)
+        if not order:
+            raise ValueError("order_not_found")
+        if order.partner_id != data.partner_id:
+            raise ValueError("partner_mismatch")
+    invoice = SalesInvoice(
+        number=number,
+        partner_id=data.partner_id,
+        order_id=data.order_id,
+        currency=data.currency,
+        issue_date=issue_date,
+        notes=data.notes,
+        discount_rate=data.discount_rate,
+    )
+    for item_in in data.items:
+        invoice.items.append(_calc_item(item_in))
+    _recalc_totals(invoice)
+    db.add(invoice)
+    db.commit()
+    db.refresh(invoice)
+    return invoice
+
+
+def get_invoice(db: Session, id: UUID) -> SalesInvoice | None:
+    return (
+        db.query(SalesInvoice)
+        .options(selectinload(SalesInvoice.items))
+        .filter(SalesInvoice.id == id)
+        .first()
+    )
+
+
+def list_invoices(
+    db: Session,
+    page: int,
+    page_size: int,
+    search: str | None = None,
+    status: str | None = None,
+    partner_id: UUID | None = None,
+) -> tuple[Sequence[SalesInvoice], int]:
+    query = db.query(SalesInvoice)
+    if search:
+        like = f"%{search}%"
+        query = query.filter(SalesInvoice.number.ilike(like))
+    if status:
+        query = query.filter(SalesInvoice.status == status)
+    if partner_id:
+        query = query.filter(SalesInvoice.partner_id == partner_id)
+    total = query.count()
+    items = (
+        query.order_by(SalesInvoice.created_at_utc.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+    return items, total
+
+
+def update_invoice(
+    db: Session, id: UUID, data: SalesInvoiceUpdate
+) -> SalesInvoice | None:
+    invoice = db.query(SalesInvoice).options(selectinload(SalesInvoice.items)).get(id)
+    if not invoice:
+        return None
+    if invoice.status != "DRAFT":
+        raise ValueError("immutable_state")
+    if data.notes is not None:
+        invoice.notes = data.notes
+    if data.discount_rate is not None:
+        invoice.discount_rate = data.discount_rate
+    if data.items is not None:
+        invoice.items.clear()
+        for item_in in data.items:
+            invoice.items.append(_calc_item(item_in))
+    _recalc_totals(invoice)
+    db.commit()
+    db.refresh(invoice)
+    return invoice
+
+
+def set_status(db: Session, id: UUID, new_status: str) -> SalesInvoice | None:
+    invoice = db.get(SalesInvoice, id)
+    if not invoice:
+        return None
+    transitions = {
+        "DRAFT": {"ISSUED", "CANCELLED"},
+        "ISSUED": {"PAID", "CANCELLED"},
+        "PAID": set(),
+        "CANCELLED": set(),
+    }
+    allowed = transitions.get(invoice.status, set())
+    if new_status not in allowed:
+        raise ValueError("invalid_status")
+    invoice.status = new_status
+    db.commit()
+    db.refresh(invoice)
+    return invoice


### PR DESCRIPTION
## Summary
- add sales invoices & invoice items tables and models
- expose CRUD-like service and API with status transitions
- wire sales invoices into FastAPI app and docs

## Testing
- `pytest -q` *(fails: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac210b1cfc832dbf8f6b5da7913c78