### PR TITLE
Add accounts receivable ledger with AR entries and payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@
      -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\
      -d '{"status":"ISSUED"}'`
 
+## Cari Hesap Akışı
+
+1. Fatura `ISSUED` olduğunda otomatik olarak `ar_entries` tablosuna borç kaydı düşer.
+2. Tahsilatlar `POST /finance/ar/payments` ile kaydedilir ve FIFO mantığıyla açık faturalara dağıtılır.
+3. `GET /finance/ar/balances/{partner_id}` uç noktası partner bazında bakiye ve fatura kırılımını döner.
+4. Bir faturanın kalan bakiyesi sıfırlanınca `POST /sales/invoices/{id}/status` ile `PAID` yapılabilir.
+
 > Port çakışması notu: Lokal Postgres 5432 kullanıyorsa compose dosyasında `5432:5432` yerine `5433:5432` map et.
 
 > **Not:** Uygulama Postgres gerektirir. `DATABASE_URL` "postgresql" ile başlamıyorsa `RuntimeError("PostgreSQL required; run inside docker-compose")` fırlatır.

--- a/backend/alembic/versions/0010_create_ar_tables.py
+++ b/backend/alembic/versions/0010_create_ar_tables.py
@@ -1,0 +1,58 @@
+"""create ar tables"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0010"
+down_revision = "0009"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        op.execute('CREATE EXTENSION IF NOT EXISTS "pgcrypto";')
+    op.create_table(
+        "ar_entries",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("partner_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("invoice_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("entry_date", sa.Date(), nullable=False, server_default=sa.func.current_date()),
+        sa.Column("type", sa.Text(), nullable=False),
+        sa.Column("amount", sa.Numeric(14, 2), nullable=False),
+        sa.Column("currency", sa.Text(), nullable=False, server_default="TRY"),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column("created_at_utc", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["partner_id"], ["partners.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["invoice_id"], ["sales_invoices.id"], ondelete="SET NULL"),
+        sa.CheckConstraint("type IN ('INVOICE','PAYMENT','REFUND','ADJUSTMENT')", name="chk_ar_entry_type"),
+        sa.CheckConstraint("amount >= 0", name="chk_ar_entry_amount_nonneg"),
+    )
+    op.create_table(
+        "ar_allocations",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("entry_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("invoice_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("amount", sa.Numeric(14, 2), nullable=False),
+        sa.ForeignKeyConstraint(["entry_id"], ["ar_entries.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["invoice_id"], ["sales_invoices.id"], ondelete="CASCADE"),
+        sa.CheckConstraint("amount > 0", name="chk_ar_allocation_amount_positive"),
+    )
+    op.create_index("ix_ar_entries_partner", "ar_entries", ["partner_id"])
+    op.create_index(
+        "ix_ar_entries_date", "ar_entries", ["entry_date", sa.text("created_at_utc DESC")]
+    )
+    op.create_index("ix_ar_allocations_invoice", "ar_allocations", ["invoice_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ar_allocations_invoice", table_name="ar_allocations")
+    op.drop_table("ar_allocations")
+    op.drop_index("ix_ar_entries_date", table_name="ar_entries")
+    op.drop_index("ix_ar_entries_partner", table_name="ar_entries")
+    op.drop_table("ar_entries")
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        op.execute('DROP EXTENSION IF EXISTS "pgcrypto";')

--- a/backend/app/api/ar.py
+++ b/backend/app/api/ar.py
@@ -1,0 +1,70 @@
+from datetime import date
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.core.deps import get_current_admin, get_current_user, get_db, get_pagination
+from app.models.user import User
+from app.schemas.ar import (
+    AREntryListResponse,
+    PartnerBalance,
+    PaymentCreate,
+    PaymentResult,
+)
+from app.services.ar_service import (
+    compute_partner_balance,
+    list_ar_entries,
+    post_payment,
+)
+
+router = APIRouter(prefix="/finance/ar", tags=["finance-ar"])
+
+
+@router.get("/balances/{partner_id}", response_model=PartnerBalance)
+def get_balance(
+    partner_id: UUID,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    return compute_partner_balance(db, partner_id)
+
+
+@router.get("/entries", response_model=AREntryListResponse)
+def list_entries(
+    partner_id: UUID,
+    pagination: tuple[int, int] = Depends(get_pagination),
+    date_from: date | None = Query(None, alias="from"),
+    date_to: date | None = Query(None, alias="to"),
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    page, page_size = pagination
+    items, total = list_ar_entries(db, partner_id, page, page_size, date_from, date_to)
+    return {"items": items, "total": total, "page": page, "page_size": page_size}
+
+
+@router.post("/payments", response_model=PaymentResult, status_code=status.HTTP_201_CREATED)
+def create_payment(
+    data: PaymentCreate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    allocations = None
+    if data.allocations is not None:
+        allocations = [a.model_dump() for a in data.allocations]
+    try:
+        entry, applied, unapplied = post_payment(
+            db,
+            data.partner_id,
+            data.amount,
+            data.currency,
+            data.note,
+            allocations,
+        )
+    except ValueError as e:
+        detail = str(e)
+        if detail in {"overallocation", "invalid_invoice_for_allocation"}:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=detail)
+        raise
+    return {"entry_id": entry.id, "applied": applied, "unapplied_amount": unapplied}

--- a/backend/app/api/sales_invoices.py
+++ b/backend/app/api/sales_invoices.py
@@ -103,8 +103,11 @@ def change_status_endpoint(
 ):
     try:
         invoice = set_status(db, invoice_id, body.status)
-    except ValueError:
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="invalid_status")
+    except ValueError as e:
+        detail = str(e)
+        if detail in {"invalid_status", "unsettled_balance", "allocated_invoice"}:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=detail)
+        raise
     if not invoice:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invoice not found")
     return invoice

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -12,4 +12,6 @@ from app.models import (
     partner,
     quote,
     sales_order,
+    sales_invoice,
+    ar,
 )  # noqa: E402,F401

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from app.api.partners import router as partners_router
 from app.api.quotes import router as quotes_router
 from app.api.sales_orders import router as sales_orders_router
 from app.api.sales_invoices import router as sales_invoices_router
+from app.api.ar import router as ar_router
 from app.core.security import hash_password
 from app.core.config import settings
 from app.db.session import SessionLocal
@@ -46,3 +47,4 @@ app.include_router(partners_router)
 app.include_router(quotes_router)
 app.include_router(sales_orders_router)
 app.include_router(sales_invoices_router)
+app.include_router(ar_router)

--- a/backend/app/models/ar.py
+++ b/backend/app/models/ar.py
@@ -1,0 +1,60 @@
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    Numeric,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from app.db.base import Base
+
+
+class AREntry(Base):
+    __tablename__ = "ar_entries"
+    __table_args__ = (
+        Index("ix_ar_entries_partner", "partner_id"),
+        Index("ix_ar_entries_date", "entry_date", text("created_at_utc DESC")),
+        CheckConstraint(
+            "type IN ('INVOICE','PAYMENT','REFUND','ADJUSTMENT')",
+            name="chk_ar_entry_type",
+        ),
+        CheckConstraint("amount >= 0", name="chk_ar_entry_amount_nonneg"),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()"))
+    partner_id = Column(UUID(as_uuid=True), ForeignKey("partners.id", ondelete="RESTRICT"), nullable=False)
+    invoice_id = Column(UUID(as_uuid=True), ForeignKey("sales_invoices.id", ondelete="SET NULL"), nullable=True)
+    entry_date = Column(Date, nullable=False, server_default=func.current_date())
+    type = Column(Text, nullable=False)
+    amount = Column(Numeric(14, 2), nullable=False)
+    currency = Column(Text, nullable=False, server_default=text("'TRY'"))
+    note = Column(Text, nullable=True)
+    created_at_utc = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+
+    allocations = relationship(
+        "ARAllocation",
+        back_populates="entry",
+        cascade="all, delete-orphan",
+    )
+
+
+class ARAllocation(Base):
+    __tablename__ = "ar_allocations"
+    __table_args__ = (
+        Index("ix_ar_allocations_invoice", "invoice_id"),
+        CheckConstraint("amount > 0", name="chk_ar_allocation_amount_positive"),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()"))
+    entry_id = Column(UUID(as_uuid=True), ForeignKey("ar_entries.id", ondelete="CASCADE"), nullable=False)
+    invoice_id = Column(UUID(as_uuid=True), ForeignKey("sales_invoices.id", ondelete="CASCADE"), nullable=False)
+    amount = Column(Numeric(14, 2), nullable=False)
+
+    entry = relationship("AREntry", back_populates="allocations")

--- a/backend/app/schemas/ar.py
+++ b/backend/app/schemas/ar.py
@@ -1,0 +1,64 @@
+from datetime import date, datetime
+from decimal import Decimal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.common import PageMeta
+
+
+class PaymentAllocationIn(BaseModel):
+    invoice_id: UUID
+    amount: Decimal = Field(..., gt=0)
+
+
+class PaymentCreate(BaseModel):
+    partner_id: UUID
+    amount: Decimal = Field(..., gt=0)
+    currency: str = 'TRY'
+    note: str | None = None
+    allocations: list[PaymentAllocationIn] | None = None
+
+
+class PaymentAllocationOut(BaseModel):
+    invoice_id: UUID
+    amount: Decimal
+    remaining_after: Decimal
+
+
+class PaymentResult(BaseModel):
+    entry_id: UUID
+    applied: list[PaymentAllocationOut]
+    unapplied_amount: Decimal
+
+
+class PartnerInvoiceBalance(BaseModel):
+    invoice_id: UUID
+    status: str
+    issued_total: Decimal
+    allocated: Decimal
+    remaining: Decimal
+
+
+class PartnerBalance(BaseModel):
+    currency: str
+    total_due: Decimal
+    by_invoice: list[PartnerInvoiceBalance]
+
+
+class AREntryPublic(BaseModel):
+    id: UUID
+    partner_id: UUID
+    invoice_id: UUID | None = None
+    entry_date: date
+    type: str
+    amount: Decimal
+    currency: str
+    note: str | None = None
+    created_at_utc: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AREntryListResponse(PageMeta):
+    items: list[AREntryPublic]

--- a/backend/app/services/ar_service.py
+++ b/backend/app/services/ar_service.py
@@ -1,0 +1,184 @@
+from datetime import date
+from decimal import Decimal
+from typing import Sequence
+from uuid import UUID
+
+from sqlalchemy import case, func
+from sqlalchemy.orm import Session
+
+from app.models.ar import ARAllocation, AREntry
+from app.models.sales_invoice import SalesInvoice
+
+
+def _allocated_amount(db: Session, invoice_id: UUID) -> Decimal:
+    total = (
+        db.query(
+            func.coalesce(
+                func.sum(
+                    case(
+                        (AREntry.type.in_(["PAYMENT", "ADJUSTMENT"]), ARAllocation.amount),
+                        (AREntry.type == "REFUND", -ARAllocation.amount),
+                        else_=0,
+                    )
+                ),
+                0,
+            )
+        )
+        .select_from(ARAllocation)
+        .join(AREntry)
+        .filter(ARAllocation.invoice_id == invoice_id)
+        .scalar()
+    )
+    return Decimal(total)
+
+
+def on_invoice_issued(db: Session, invoice: SalesInvoice) -> AREntry:
+    existing = (
+        db.query(AREntry)
+        .filter(AREntry.invoice_id == invoice.id, AREntry.type == "INVOICE")
+        .first()
+    )
+    if existing:
+        return existing
+    entry = AREntry(
+        partner_id=invoice.partner_id,
+        invoice_id=invoice.id,
+        entry_date=invoice.issue_date or date.today(),
+        type="INVOICE",
+        amount=invoice.grand_total,
+        currency=invoice.currency,
+    )
+    db.add(entry)
+    db.commit()
+    db.refresh(entry)
+    return entry
+
+
+def post_payment(
+    db: Session,
+    partner_id: UUID,
+    amount: Decimal,
+    currency: str = "TRY",
+    note: str | None = None,
+    allocations: list[dict] | None = None,
+) -> tuple[AREntry, list[dict], Decimal]:
+    if amount <= 0:
+        raise ValueError("amount_nonpositive")
+    entry = AREntry(
+        partner_id=partner_id,
+        type="PAYMENT",
+        amount=amount,
+        currency=currency,
+        note=note,
+    )
+    db.add(entry)
+    db.flush()
+    remaining_payment = amount
+    applied: list[dict] = []
+    if allocations:
+        total_alloc = sum((a["amount"] for a in allocations), Decimal("0"))
+        if total_alloc > amount:
+            raise ValueError("overallocation")
+        for alloc in allocations:
+            invoice = db.get(SalesInvoice, alloc["invoice_id"])
+            if not invoice or invoice.partner_id != partner_id or invoice.status in {"CANCELLED", "PAID"}:
+                raise ValueError("invalid_invoice_for_allocation")
+            remaining = invoice.grand_total - _allocated_amount(db, invoice.id)
+            if alloc["amount"] > remaining:
+                raise ValueError("overallocation")
+            db.add(
+                ARAllocation(
+                    entry_id=entry.id,
+                    invoice_id=invoice.id,
+                    amount=alloc["amount"],
+                )
+            )
+            remaining_payment -= alloc["amount"]
+            remaining_after = remaining - alloc["amount"]
+            applied.append(
+                {
+                    "invoice_id": invoice.id,
+                    "amount": alloc["amount"],
+                    "remaining_after": remaining_after,
+                }
+            )
+    else:
+        invoices: Sequence[SalesInvoice] = (
+            db.query(SalesInvoice)
+            .filter(
+                SalesInvoice.partner_id == partner_id,
+                SalesInvoice.status != "CANCELLED",
+            )
+            .order_by(SalesInvoice.issue_date, SalesInvoice.created_at_utc)
+            .all()
+        )
+        for invoice in invoices:
+            remaining = invoice.grand_total - _allocated_amount(db, invoice.id)
+            if remaining <= 0:
+                continue
+            alloc_amt = remaining if remaining < remaining_payment else remaining_payment
+            if alloc_amt <= 0:
+                break
+            db.add(
+                ARAllocation(entry_id=entry.id, invoice_id=invoice.id, amount=alloc_amt)
+            )
+            remaining_payment -= alloc_amt
+            remaining_after = remaining - alloc_amt
+            applied.append(
+                {
+                    "invoice_id": invoice.id,
+                    "amount": alloc_amt,
+                    "remaining_after": remaining_after,
+                }
+            )
+            if remaining_payment <= 0:
+                break
+    db.commit()
+    db.refresh(entry)
+    return entry, applied, remaining_payment
+
+
+def compute_partner_balance(db: Session, partner_id: UUID) -> dict:
+    invoices: Sequence[SalesInvoice] = (
+        db.query(SalesInvoice).filter(SalesInvoice.partner_id == partner_id).all()
+    )
+    by_invoice: list[dict] = []
+    total_due = Decimal("0")
+    for inv in invoices:
+        allocated = _allocated_amount(db, inv.id)
+        remaining = inv.grand_total - allocated
+        by_invoice.append(
+            {
+                "invoice_id": inv.id,
+                "status": inv.status,
+                "issued_total": inv.grand_total,
+                "allocated": allocated,
+                "remaining": remaining,
+            }
+        )
+        if inv.status != "CANCELLED":
+            total_due += remaining
+    return {"currency": "TRY", "total_due": total_due, "by_invoice": by_invoice}
+
+
+def list_ar_entries(
+    db: Session,
+    partner_id: UUID,
+    page: int,
+    page_size: int,
+    date_from: date | None = None,
+    date_to: date | None = None,
+) -> tuple[Sequence[AREntry], int]:
+    query = db.query(AREntry).filter(AREntry.partner_id == partner_id)
+    if date_from:
+        query = query.filter(AREntry.entry_date >= date_from)
+    if date_to:
+        query = query.filter(AREntry.entry_date <= date_to)
+    total = query.count()
+    items = (
+        query.order_by(AREntry.entry_date.desc(), AREntry.created_at_utc.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+    return items, total

--- a/backend/tests/api/test_ar.py
+++ b/backend/tests/api/test_ar.py
@@ -1,0 +1,106 @@
+from decimal import Decimal
+
+from app.db.session import SessionLocal
+from app.models.ar import AREntry
+
+
+def create_partner(client, admin_token):
+    res = client.post(
+        "/partners",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"name": "Cust", "type": "customer", "tax_number": "TN1"},
+    )
+    assert res.status_code == 201
+    return res.json()["id"]
+
+
+def create_product(client, admin_token):
+    res = client.post(
+        "/products",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"name": "Prod", "sku": "SKU1", "price": 100},
+    )
+    assert res.status_code == 201
+    return res.json()["id"]
+
+
+def create_invoice(client, admin_token, partner_id, product_id):
+    payload = {
+        "partner_id": partner_id,
+        "items": [{"product_id": product_id, "quantity": 1, "unit_price": 100}],
+    }
+    res = client.post(
+        "/sales/invoices",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=payload,
+    )
+    assert res.status_code == 201
+    return res.json()
+
+
+def test_ar_flow_issue_payment_balance_paid(client, admin_token, user_token):
+    partner_id = create_partner(client, admin_token)
+    product_id = create_product(client, admin_token)
+    invoice = create_invoice(client, admin_token, partner_id, product_id)
+    inv_id = invoice["id"]
+    grand_total = Decimal(str(invoice["grand_total"]))
+
+    # issue invoice
+    res_issue = client.post(
+        f"/sales/invoices/{inv_id}/status",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"status": "ISSUED"},
+    )
+    assert res_issue.status_code == 200
+
+    # ar entry exists once
+    db = SessionLocal()
+    entries = (
+        db.query(AREntry)
+        .filter(AREntry.invoice_id == inv_id, AREntry.type == "INVOICE")
+        .all()
+    )
+    assert len(entries) == 1
+    db.close()
+
+    # balance after issue
+    res_bal = client.get(
+        f"/finance/ar/balances/{partner_id}",
+        headers={"Authorization": f"Bearer {user_token}"},
+    )
+    assert res_bal.status_code == 200
+    bal = res_bal.json()
+    assert float(bal["total_due"]) == float(grand_total)
+
+    # attempt to pay status before payment -> 409
+    res_paid_fail = client.post(
+        f"/sales/invoices/{inv_id}/status",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"status": "PAID"},
+    )
+    assert res_paid_fail.status_code == 409
+
+    # post payment
+    res_pay = client.post(
+        "/finance/ar/payments",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"partner_id": partner_id, "amount": str(grand_total)},
+    )
+    assert res_pay.status_code == 201
+    pay_data = res_pay.json()
+    assert pay_data["applied"][0]["invoice_id"] == inv_id
+
+    # balance after payment
+    res_bal2 = client.get(
+        f"/finance/ar/balances/{partner_id}",
+        headers={"Authorization": f"Bearer {user_token}"},
+    )
+    assert float(res_bal2.json()["total_due"]) == 0.0
+
+    # now set to PAID
+    res_paid = client.post(
+        f"/sales/invoices/{inv_id}/status",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"status": "PAID"},
+    )
+    assert res_paid.status_code == 200


### PR DESCRIPTION
## Summary
- add AR tables and SQLAlchemy models for entries and allocations
- implement AR service with invoice posting, payment allocations, balance queries
- expose finance AR API endpoints and integrate with invoice status flow

## Testing
- `ruff check app tests` (fails: F401 unused imports in existing modules)
- `pytest` *(fails: httpx dependency missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac28e12180832d9c84af77990b40c5