### PR TITLE
feat: add dashboard summary and stock threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@
      -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\
      -d '{"status":"ISSUED"}'`
 
+15. Ürün restock_level güncelleme:
+   `PROD_ID=<ürün_id>`
+   `curl -s -X PUT http://localhost:8000/products/$PROD_ID \\
+     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\
+     -d '{"restock_level":10}'`
+
+16. Dashboard özeti:
+   `curl -s http://localhost:8000/dashboard/summary -H "Authorization: Bearer $TOKEN"`
+
 ## Cari Hesap Akışı
 
 1. Fatura `ISSUED` olduğunda otomatik olarak `ar_entries` tablosuna borç kaydı düşer.

--- a/backend/alembic/versions/0011_add_restock_level_to_products.py
+++ b/backend/alembic/versions/0011_add_restock_level_to_products.py
@@ -1,0 +1,21 @@
+"""add restock_level to products"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0011"
+down_revision = "0010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "products",
+        sa.Column("restock_level", sa.Numeric(14, 3), nullable=False, server_default=sa.text("0")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("products", "restock_level")
+

--- a/backend/app/api/dashboard.py
+++ b/backend/app/api/dashboard.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.core.deps import get_current_user, get_db
+from app.models.user import User
+from app.services.dashboard_service import (
+    get_ar_summary,
+    get_low_stock,
+    get_sales_summary,
+    get_top_customers,
+)
+
+router = APIRouter(prefix="/dashboard", tags=["dashboard"])
+
+
+@router.get("/summary")
+def dashboard_summary(
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    return {
+        "sales": get_sales_summary(db),
+        "ar": get_ar_summary(db),
+        "stock": {"low": get_low_stock(db)},
+        "top_customers": get_top_customers(db),
+    }
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from app.api.quotes import router as quotes_router
 from app.api.sales_orders import router as sales_orders_router
 from app.api.sales_invoices import router as sales_invoices_router
 from app.api.ar import router as ar_router
+from app.api.dashboard import router as dashboard_router
 from app.core.security import hash_password
 from app.core.config import settings
 from app.db.session import SessionLocal
@@ -48,3 +49,4 @@ app.include_router(quotes_router)
 app.include_router(sales_orders_router)
 app.include_router(sales_invoices_router)
 app.include_router(ar_router)
+app.include_router(dashboard_router)

--- a/backend/app/models/product.py
+++ b/backend/app/models/product.py
@@ -12,4 +12,5 @@ class Product(Base):
     sku = Column(Text, nullable=False, unique=True)
     price = Column(Numeric(12, 2), nullable=False, server_default=text("0"))
     is_active = Column(Boolean, nullable=False, server_default=text("true"))
+    restock_level = Column(Numeric(14, 3), nullable=False, server_default=text("0"))
     created_at_utc = Column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/backend/app/schemas/product.py
+++ b/backend/app/schemas/product.py
@@ -12,6 +12,7 @@ class ProductBase(BaseModel):
     sku: str = Field(..., pattern=r"^[A-Za-z0-9_-]{3,40}$")
     price: Decimal = Field(..., ge=0)
     is_active: bool = True
+    restock_level: Decimal = Field(0, ge=0)
 
 
 class ProductCreate(ProductBase):
@@ -23,6 +24,7 @@ class ProductUpdate(BaseModel):
     sku: str | None = Field(None, pattern=r"^[A-Za-z0-9_-]{3,40}$")
     price: Decimal | None = Field(None, ge=0)
     is_active: bool | None = None
+    restock_level: Decimal | None = Field(None, ge=0)
 
 
 class ProductPublic(BaseModel):
@@ -31,6 +33,7 @@ class ProductPublic(BaseModel):
     sku: str
     price: Decimal
     is_active: bool
+    restock_level: Decimal
     created_at_utc: datetime
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/dashboard_service.py
+++ b/backend/app/services/dashboard_service.py
@@ -1,0 +1,164 @@
+from datetime import date, timedelta
+from decimal import Decimal
+from sqlalchemy import case, func
+from sqlalchemy.orm import Session
+
+from app.models.product import Product
+from app.models.sales_invoice import SalesInvoice
+from app.models.ar import ARAllocation, AREntry
+from app.models.partner import Partner
+from app.models.stock_movement import StockMovement
+
+
+def get_sales_summary(db: Session, today: date | None = None) -> dict:
+    today = today or date.today()
+    month_start = today.replace(day=1)
+    next_month = (month_start + timedelta(days=32)).replace(day=1)
+
+    today_total = (
+        db.query(func.coalesce(func.sum(SalesInvoice.grand_total), 0))
+        .filter(
+            SalesInvoice.status.in_(["ISSUED", "PAID"]),
+            SalesInvoice.issue_date == today,
+        )
+        .scalar()
+        or Decimal("0")
+    )
+    month_total = (
+        db.query(func.coalesce(func.sum(SalesInvoice.grand_total), 0))
+        .filter(
+            SalesInvoice.status.in_(["ISSUED", "PAID"]),
+            SalesInvoice.issue_date >= month_start,
+            SalesInvoice.issue_date < next_month,
+        )
+        .scalar()
+        or Decimal("0")
+    )
+    return {"today": today_total, "month": month_total}
+
+
+def get_ar_summary(db: Session) -> dict:
+    invoices = (
+        db.query(SalesInvoice)
+        .filter(SalesInvoice.status != "CANCELLED")
+        .all()
+    )
+    alloc_rows = (
+        db.query(
+            ARAllocation.invoice_id,
+            func.coalesce(
+                func.sum(
+                    case(
+                        (AREntry.type.in_(["PAYMENT", "ADJUSTMENT"]), ARAllocation.amount),
+                        (AREntry.type == "REFUND", -ARAllocation.amount),
+                        else_=0,
+                    )
+                ),
+                0,
+            ).label("allocated"),
+        )
+        .join(AREntry)
+        .group_by(ARAllocation.invoice_id)
+        .all()
+    )
+    alloc_map = {row.invoice_id: Decimal(row.allocated) for row in alloc_rows}
+
+    open_total = Decimal("0")
+    bucket_0_30 = Decimal("0")
+    bucket_31_60 = Decimal("0")
+    bucket_61_90 = Decimal("0")
+    bucket_90_plus = Decimal("0")
+    today = date.today()
+    for inv in invoices:
+        allocated = alloc_map.get(inv.id, Decimal("0"))
+        remaining = inv.grand_total - allocated
+        if remaining <= 0:
+            continue
+        open_total += remaining
+        if inv.status == "ISSUED":
+            age = (today - inv.issue_date).days
+            if age <= 30:
+                bucket_0_30 += remaining
+            elif age <= 60:
+                bucket_31_60 += remaining
+            elif age <= 90:
+                bucket_61_90 += remaining
+            else:
+                bucket_90_plus += remaining
+    return {
+        "open_total": open_total,
+        "aging": {
+            "0_30": bucket_0_30,
+            "31_60": bucket_31_60,
+            "61_90": bucket_61_90,
+            "90_plus": bucket_90_plus,
+        },
+    }
+
+
+def get_low_stock(db: Session) -> list[dict]:
+    qty_sub = (
+        db.query(
+            StockMovement.product_id,
+            func.coalesce(
+                func.sum(
+                    case(
+                        (StockMovement.direction == "IN", StockMovement.quantity),
+                        else_=-StockMovement.quantity,
+                    )
+                ),
+                0,
+            ).label("qty"),
+        )
+        .group_by(StockMovement.product_id)
+        .subquery()
+    )
+    rows = (
+        db.query(
+            Product.id.label("product_id"),
+            Product.sku,
+            Product.name,
+            func.coalesce(qty_sub.c.qty, 0).label("total"),
+            Product.restock_level,
+        )
+        .outerjoin(qty_sub, Product.id == qty_sub.c.product_id)
+        .filter(
+            Product.restock_level > 0,
+            func.coalesce(qty_sub.c.qty, 0) < Product.restock_level,
+        )
+        .all()
+    )
+    return [
+        {
+            "product_id": r.product_id,
+            "sku": r.sku,
+            "name": r.name,
+            "total": r.total,
+            "restock_level": r.restock_level,
+        }
+        for r in rows
+    ]
+
+
+def get_top_customers(db: Session, limit: int = 5) -> list[dict]:
+    cutoff = date.today() - timedelta(days=90)
+    rows = (
+        db.query(
+            SalesInvoice.partner_id,
+            Partner.name,
+            func.sum(SalesInvoice.grand_total).label("total"),
+        )
+        .join(Partner, Partner.id == SalesInvoice.partner_id)
+        .filter(
+            SalesInvoice.status.in_(["ISSUED", "PAID"]),
+            SalesInvoice.issue_date >= cutoff,
+        )
+        .group_by(SalesInvoice.partner_id, Partner.name)
+        .order_by(func.sum(SalesInvoice.grand_total).desc())
+        .limit(limit)
+        .all()
+    )
+    return [
+        {"partner_id": r.partner_id, "name": r.name, "total": r.total}
+        for r in rows
+    ]

--- a/backend/tests/api/test_dashboard.py
+++ b/backend/tests/api/test_dashboard.py
@@ -1,0 +1,65 @@
+from datetime import date
+from uuid import uuid4
+
+from app.db.session import SessionLocal
+from app.models.product import Product
+from app.models.warehouse import Warehouse
+from app.models.partner import Partner
+from app.models.stock_movement import StockMovement
+from app.models.sales_invoice import SalesInvoice
+from app.services.ar_service import on_invoice_issued
+
+
+def _setup_data():
+    db = SessionLocal()
+    prod = Product(id=uuid4(), name="P1", sku="SKU1", price=1, restock_level=5)
+    wh = Warehouse(id=uuid4(), name="Main", code="MAIN")
+    partner = Partner(id=uuid4(), name="Cust", type="customer")
+    db.add_all([prod, wh, partner])
+    db.commit()
+    move = StockMovement(
+        id=uuid4(),
+        product_id=prod.id,
+        warehouse_id=wh.id,
+        direction="IN",
+        quantity=2,
+    )
+    db.add(move)
+    inv = SalesInvoice(
+        id=uuid4(),
+        number="I-1",
+        partner_id=partner.id,
+        currency="TRY",
+        status="ISSUED",
+        issue_date=date.today(),
+        subtotal=100,
+        tax_total=0,
+        grand_total=100,
+    )
+    db.add(inv)
+    db.commit()
+    on_invoice_issued(db, inv)
+    db.close()
+    return partner.id
+
+
+def test_dashboard_requires_auth(client):
+    res = client.get("/dashboard/summary")
+    assert res.status_code == 401
+
+
+def test_dashboard_summary(client, user_token):
+    partner_id = _setup_data()
+    res = client.get(
+        "/dashboard/summary",
+        headers={"Authorization": f"Bearer {user_token}"},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert float(data["sales"]["today"]) == 100
+    assert float(data["sales"]["month"]) == 100
+    assert float(data["ar"]["open_total"]) == 100
+    assert float(data["ar"]["aging"]["0_30"]) == 100
+    assert data["stock"]["low"][0]["sku"] == "SKU1"
+    assert len(data["top_customers"]) == 1
+    assert data["top_customers"][0]["partner_id"] == str(partner_id)


### PR DESCRIPTION
## Summary
- add restock_level to products and expose through product schema
- implement dashboard service and API with sales, receivables, stock, top customers
- document usage and examples in README

## Testing
- `pytest -q` *(fails: NOT NULL constraint failed and other SQLite-related errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2d051d80832da533fb44603afbdb