### PR TITLE
feat(web): add React dashboard skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,11 @@ docker compose -f ops/docker-compose.yml exec backend pytest -q
 ```
 
 Lokal makinede `alembic upgrade head` veya `pytest` çalıştırmayın.
+
+## Web
+
+1. `cd web && cp .env.example .env`
+2. `.env` içindeki `VITE_API_BASE` değerini backend URL'ine göre düzenle
+3. `npm install`
+4. `npm run dev`
+5. Login: `admin@example.com` / `ChangeMe123!`

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE=http://localhost:8000

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.dist
+dist
+.env

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dogus Cam</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "web",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
+    "@tanstack/react-query": "^5.51.11",
+    "zod": "^3.22.4",
+    "axios": "^1.6.8"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.33",
+    "@types/react-dom": "^18.2.14",
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "^5.2.2",
+    "vite": "^5.2.0"
+  }
+}

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { NavLink, useNavigate } from 'react-router-dom'
+import { useAuth } from '../store/auth'
+
+const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { logout } = useAuth()
+  const navigate = useNavigate()
+
+  const handleLogout = () => {
+    logout()
+    navigate('/login')
+  }
+
+  return (
+    <div style={{ display: 'flex', width: '100%' }}>
+      <aside style={{ width: 200, borderRight: '1px solid #ccc', padding: '1rem' }}>
+        <h2>DogusCam</h2>
+        <nav style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          <NavLink to="/dashboard">Dashboard</NavLink>
+          <NavLink to="/products">Products</NavLink>
+          <NavLink to="/partners">Partners</NavLink>
+          <NavLink to="/sales/quotes">Sales</NavLink>
+        </nav>
+      </aside>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <header
+          style={{
+            borderBottom: '1px solid #ccc',
+            padding: '0.5rem 1rem',
+            display: 'flex',
+            justifyContent: 'space-between',
+          }}
+        >
+          <span>Admin Panel</span>
+          <button onClick={handleLogout}>Logout</button>
+        </header>
+        <main style={{ flex: 1 }}>{children}</main>
+      </div>
+    </div>
+  )
+}
+
+export default Layout

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,0 +1,9 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+}
+
+#root {
+  min-height: 100vh;
+  display: flex;
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,0 +1,27 @@
+import axios from 'axios'
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE,
+})
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token')
+  if (token) {
+    config.headers = config.headers || {}
+    config.headers.Authorization = `Bearer ${token}`
+  }
+  return config
+})
+
+api.interceptors.response.use(
+  (res) => res,
+  (err) => {
+    if (err.response?.status === 401) {
+      localStorage.removeItem('token')
+      window.location.href = '/login'
+    }
+    return Promise.reject(err)
+  }
+)
+
+export default api

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { AuthProvider } from './store/auth'
+import { AppRoutes } from './routes'
+import './index.css'
+
+const queryClient = new QueryClient()
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <BrowserRouter>
+          <AppRoutes />
+        </BrowserRouter>
+      </AuthProvider>
+    </QueryClientProvider>
+  </React.StrictMode>
+)

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,0 +1,84 @@
+import { useQuery } from '@tanstack/react-query'
+import api from '../lib/api'
+import { dashboardSummarySchema, DashboardSummary } from '../types/dashboard'
+
+const Dashboard = () => {
+  const { data, isLoading, error } = useQuery<DashboardSummary>({
+    queryKey: ['dashboardSummary'],
+    queryFn: async () => {
+      const res = await api.get('/dashboard/summary')
+      return dashboardSummarySchema.parse(res.data)
+    },
+  })
+
+  if (isLoading) return <p>Loading...</p>
+  if (error) return <p>Error loading summary</p>
+
+  return (
+    <div style={{ padding: '1rem', flex: 1 }}>
+      <h1>Dashboard</h1>
+      <div style={{ display: 'flex', gap: '1rem' }}>
+        <div style={{ border: '1px solid #ccc', padding: '1rem' }}>
+          <strong>Bugün satış</strong>
+          <div>{data!.salesToday}</div>
+        </div>
+        <div style={{ border: '1px solid #ccc', padding: '1rem' }}>
+          <strong>Bu ay satış</strong>
+          <div>{data!.salesThisMonth}</div>
+        </div>
+      </div>
+
+      <h2 style={{ marginTop: '1rem' }}>Açık Alacaklar</h2>
+      <div>{data!.receivablesTotal}</div>
+      <ul>
+        {data!.receivablesAging.map((a) => (
+          <li key={a.period}>
+            {a.period}: {a.amount}
+          </li>
+        ))}
+      </ul>
+
+      <h2>Düşük Stok</h2>
+      <table border={1} cellPadding={4} style={{ borderCollapse: 'collapse' }}>
+        <thead>
+          <tr>
+            <th>SKU</th>
+            <th>Ad</th>
+            <th>Total</th>
+            <th>Restock Level</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data!.lowStock.map((item) => (
+            <tr key={item.sku}>
+              <td>{item.sku}</td>
+              <td>{item.name}</td>
+              <td>{item.total}</td>
+              <td>{item.restock_level}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h2>En iyi müşteriler</h2>
+      <table border={1} cellPadding={4} style={{ borderCollapse: 'collapse' }}>
+        <thead>
+          <tr>
+            <th>Ad</th>
+            <th>Toplam</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data!.topCustomers.map((c, idx) => (
+            <tr key={idx}>
+              <td>{c.name}</td>
+              <td>{c.total}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default Dashboard

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { z } from 'zod'
+import { useAuth } from '../store/auth'
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+})
+
+const Login = () => {
+  const { login } = useAuth()
+  const navigate = useNavigate()
+  const [form, setForm] = useState({ email: '', password: '' })
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    const parsed = schema.safeParse(form)
+    if (!parsed.success) {
+      setError('Invalid credentials')
+      return
+    }
+    try {
+      await login(form.email, form.password)
+      navigate('/dashboard')
+    } catch (err: any) {
+      setError(err.response?.data?.detail || 'Login failed')
+    }
+  }
+
+  return (
+    <div style={{ margin: '2rem auto', maxWidth: 300 }}>
+      <h1>Login</h1>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <input
+          type="email"
+          placeholder="Email"
+          value={form.email}
+          onChange={(e) => setForm({ ...form, email: e.target.value })}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={form.password}
+          onChange={(e) => setForm({ ...form, password: e.target.value })}
+        />
+        <button type="submit">Login</button>
+      </form>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+    </div>
+  )
+}
+
+export default Login

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -1,0 +1,31 @@
+import { Routes, Route, Navigate } from 'react-router-dom'
+import { useAuth } from './store/auth'
+import Login from './pages/Login'
+import Dashboard from './pages/Dashboard'
+import Layout from './components/Layout'
+
+const PrivateRoute = ({ children }: { children: JSX.Element }) => {
+  const { token } = useAuth()
+  return token ? children : <Navigate to="/login" replace />
+}
+
+const PublicRoute = ({ children }: { children: JSX.Element }) => {
+  const { token } = useAuth()
+  return token ? <Navigate to="/dashboard" replace /> : children
+}
+
+export const AppRoutes = () => (
+  <Routes>
+    <Route path="/login" element={<PublicRoute><Login /></PublicRoute>} />
+    <Route
+      path="/dashboard"
+      element={
+        <PrivateRoute>
+          <Layout>
+            <Dashboard />
+          </Layout>
+        </PrivateRoute>
+      }
+    />
+  </Routes>
+)

--- a/web/src/store/auth.ts
+++ b/web/src/store/auth.ts
@@ -1,0 +1,50 @@
+import React, { createContext, useContext, useState } from 'react'
+import api from '../lib/api'
+
+interface User {
+  id: string
+  email: string
+  role: string
+}
+
+interface AuthContextProps {
+  token: string | null
+  currentUser: User | null
+  login: (email: string, password: string) => Promise<void>
+  logout: () => void
+  fetchMe: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthContextProps>({} as AuthContextProps)
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [token, setToken] = useState<string | null>(localStorage.getItem('token'))
+  const [currentUser, setCurrentUser] = useState<User | null>(null)
+
+  const fetchMe = async () => {
+    const res = await api.get('/auth/me')
+    setCurrentUser(res.data)
+  }
+
+  const login = async (email: string, password: string) => {
+    const res = await api.post('/auth/login', { email, password })
+    const t = res.data.token || res.data.access_token
+    localStorage.setItem('token', t)
+    setToken(t)
+    await fetchMe()
+  }
+
+  const logout = () => {
+    localStorage.removeItem('token')
+    setToken(null)
+    setCurrentUser(null)
+  }
+
+  return (
+    <AuthContext.Provider value={{ token, currentUser, login, logout, fetchMe }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export const useAuth = () => useContext(AuthContext)

--- a/web/src/types/dashboard.ts
+++ b/web/src/types/dashboard.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod'
+
+export const dashboardSummarySchema = z.object({
+  salesToday: z.number(),
+  salesThisMonth: z.number(),
+  receivablesTotal: z.number(),
+  receivablesAging: z.array(
+    z.object({
+      period: z.string(),
+      amount: z.number(),
+    })
+  ),
+  lowStock: z.array(
+    z.object({
+      sku: z.string(),
+      name: z.string(),
+      total: z.number(),
+      restock_level: z.number(),
+    })
+  ),
+  topCustomers: z.array(
+    z.object({
+      name: z.string(),
+      total: z.number(),
+    })
+  ),
+})
+
+export type DashboardSummary = z.infer<typeof dashboardSummarySchema>

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- scaffold minimal Vite React TS frontend with routing and auth
- add dashboard summary page consuming FastAPI endpoints
- document web setup steps in root README

## Testing
- `npm run build` *(fails: tsc not found)*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68ac319370c8832d85057fbc6465e816