### PR TITLE
feat: add partners management UI with CRUD and filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,4 +158,4 @@ Lokal makinede `alembic upgrade head` veya `pytest` çalıştırmayın.
 3. `npm install`
 4. `npm run dev`
 5. Login: `admin@example.com` / `ChangeMe123!`
-6. Giriş yaptıktan sonra sidebar'dan **Products** linkine tıklayarak ürün listesini görüntüleyebilirsiniz. Admin rolünde olmayan kullanıcılar sadece listeyi görüntüler.
+6. Giriş yaptıktan sonra sidebar'dan **Products** veya **Partners** linklerine tıklayarak listeleri görüntüleyebilirsiniz. Partners sayfasında arama kutusu, type filtresi ve sayfalama bulunur. Admin rolünde olmayan kullanıcılar bu sayfada yalnızca listeyi görüntüler.

--- a/web/src/components/PartnerForm.tsx
+++ b/web/src/components/PartnerForm.tsx
@@ -1,0 +1,134 @@
+import React, { useState } from 'react'
+import {
+  partnerCreateSchema,
+  partnerUpdateSchema,
+  Partner,
+  PartnerCreate,
+  PartnerUpdate,
+} from '../types/partner'
+
+interface Props {
+  mode: 'create' | 'edit'
+  initial?: Partner
+  onSubmit: (data: PartnerCreate | PartnerUpdate) => void
+  onCancel: () => void
+  error?: string
+}
+
+const PartnerForm: React.FC<Props> = ({ mode, initial, onSubmit, onCancel, error }) => {
+  const [form, setForm] = useState({
+    name: initial?.name || '',
+    type: initial?.type || 'customer',
+    email: initial?.email || '',
+    phone: initial?.phone || '',
+    tax_number: initial?.tax_number || '',
+    billing_address: initial?.billing_address || '',
+    shipping_address: initial?.shipping_address || '',
+    is_active: initial?.is_active ?? true,
+  })
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value, type, checked } = e.target as HTMLInputElement
+    setForm((f) => ({ ...f, [name]: type === 'checkbox' ? checked : value }))
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const schema = mode === 'edit' ? partnerUpdateSchema : partnerCreateSchema
+    const payload: any = {
+      ...form,
+      email: form.email === '' ? undefined : form.email,
+      phone: form.phone === '' ? undefined : form.phone,
+      tax_number: form.tax_number === '' ? undefined : form.tax_number,
+      billing_address: form.billing_address === '' ? undefined : form.billing_address,
+      shipping_address: form.shipping_address === '' ? undefined : form.shipping_address,
+    }
+    const parsed = schema.safeParse(payload)
+    if (!parsed.success) {
+      const errs: Record<string, string> = {}
+      parsed.error.errors.forEach((er) => {
+        const key = er.path[0] as string
+        errs[key] = er.message
+      })
+      setErrors(errs)
+      return
+    }
+    setErrors({})
+    onSubmit(parsed.data)
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}
+    >
+      {error && <div style={{ color: 'red' }}>{error}</div>}
+      <label>
+        Name
+        <input name="name" value={form.name} onChange={handleChange} />
+        {errors.name && <span style={{ color: 'red' }}>{errors.name}</span>}
+      </label>
+      <label>
+        Type
+        <select name="type" value={form.type} onChange={handleChange}>
+          <option value="customer">Customer</option>
+          <option value="supplier">Supplier</option>
+          <option value="both">Both</option>
+        </select>
+        {errors.type && <span style={{ color: 'red' }}>{errors.type}</span>}
+      </label>
+      <label>
+        Email
+        <input name="email" value={form.email} onChange={handleChange} />
+        {errors.email && <span style={{ color: 'red' }}>{errors.email}</span>}
+      </label>
+      <label>
+        Phone
+        <input name="phone" value={form.phone} onChange={handleChange} />
+        {errors.phone && <span style={{ color: 'red' }}>{errors.phone}</span>}
+      </label>
+      <label>
+        Tax Number
+        <input name="tax_number" value={form.tax_number} onChange={handleChange} />
+        {errors.tax_number && <span style={{ color: 'red' }}>{errors.tax_number}</span>}
+      </label>
+      <label>
+        Billing Address
+        <input name="billing_address" value={form.billing_address} onChange={handleChange} />
+        {errors.billing_address && (
+          <span style={{ color: 'red' }}>{errors.billing_address}</span>
+        )}
+      </label>
+      <label>
+        Shipping Address
+        <input
+          name="shipping_address"
+          value={form.shipping_address}
+          onChange={handleChange}
+        />
+        {errors.shipping_address && (
+          <span style={{ color: 'red' }}>{errors.shipping_address}</span>
+        )}
+      </label>
+      <label>
+        Is Active
+        <input
+          name="is_active"
+          type="checkbox"
+          checked={form.is_active}
+          onChange={handleChange}
+        />
+      </label>
+      <div style={{ display: 'flex', gap: '0.5rem' }}>
+        <button type="submit">{mode === 'create' ? 'Create' : 'Update'}</button>
+        <button type="button" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  )
+}
+
+export default PartnerForm
+

--- a/web/src/lib/partners.ts
+++ b/web/src/lib/partners.ts
@@ -1,0 +1,70 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import api from './api'
+import { Partner, PartnerCreate, PartnerUpdate } from '../types/partner'
+
+interface ListParams {
+  search: string
+  type: string
+  page: number
+  pageSize: number
+}
+
+export const listPartners = ({ search, type, page, pageSize }: ListParams) =>
+  useQuery({
+    queryKey: ['partners', { search, type, page, pageSize }],
+    queryFn: async () => {
+      const res = await api.get('/partners', {
+        params: { search, type, page, page_size: pageSize },
+      })
+      return res.data as {
+        items: Partner[]
+        total: number
+        page: number
+        page_size: number
+      }
+    },
+  })
+
+export const getPartner = (id: string) =>
+  useQuery({
+    queryKey: ['partners', id],
+    queryFn: async () => {
+      const res = await api.get(`/partners/${id}`)
+      return res.data as Partner
+    },
+    enabled: !!id,
+  })
+
+export const createPartner = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (payload: PartnerCreate) =>
+      api.post('/partners', payload).then((res) => res.data as Partner),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['partners'] })
+    },
+  })
+}
+
+export const updatePartner = (id: string) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (payload: PartnerUpdate) =>
+      api.put(`/partners/${id}`, payload).then((res) => res.data as Partner),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['partners'] })
+      queryClient.invalidateQueries({ queryKey: ['partners', id] })
+    },
+  })
+}
+
+export const deletePartner = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => api.delete(`/partners/${id}`).then((res) => res.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['partners'] })
+    },
+  })
+}
+

--- a/web/src/pages/Partners.tsx
+++ b/web/src/pages/Partners.tsx
@@ -1,0 +1,206 @@
+import React, { useState, useEffect } from 'react'
+import { useAuth } from '../store/auth'
+import {
+  listPartners,
+  createPartner,
+  updatePartner,
+  deletePartner,
+} from '../lib/partners'
+import { Partner, PartnerCreate, PartnerUpdate } from '../types/partner'
+import PartnerForm from '../components/PartnerForm'
+import ConfirmDialog from '../components/ConfirmDialog'
+
+const Partners: React.FC = () => {
+  const { currentUser } = useAuth()
+  const isAdmin = currentUser?.role === 'admin'
+
+  const [searchInput, setSearchInput] = useState('')
+  const [search, setSearch] = useState('')
+  const [type, setType] = useState('')
+  const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState(10)
+  const [showForm, setShowForm] = useState(false)
+  const [editing, setEditing] = useState<Partner | null>(null)
+  const [formError, setFormError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setSearch(searchInput)
+      setPage(1)
+    }, 300)
+    return () => clearTimeout(t)
+  }, [searchInput])
+
+  const { data, isLoading, isError } = listPartners({ search, type, page, pageSize })
+
+  const createMutation = createPartner()
+  const updateMutation = editing ? updatePartner(editing.id) : null
+  const deleteMutation = deletePartner()
+
+  const openNew = () => {
+    setEditing(null)
+    setFormError(null)
+    setShowForm(true)
+  }
+
+  const openEdit = (p: Partner) => {
+    setEditing(p)
+    setFormError(null)
+    setShowForm(true)
+  }
+
+  const handleSubmit = async (payload: PartnerCreate | PartnerUpdate) => {
+    try {
+      if (editing) {
+        await updateMutation!.mutateAsync(payload as PartnerUpdate)
+      } else {
+        await createMutation.mutateAsync(payload as PartnerCreate)
+      }
+      setShowForm(false)
+    } catch (err: any) {
+      setFormError(err.response?.data?.detail || 'Error')
+    }
+  }
+
+  const handleDelete = (id: string) => {
+    deleteMutation.mutate(id)
+  }
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <div
+        style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '1rem' }}
+      >
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <input
+            placeholder="Search"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+          />
+          <select
+            value={type}
+            onChange={(e) => {
+              setType(e.target.value)
+              setPage(1)
+            }}
+          >
+            <option value="">All</option>
+            <option value="customer">Customer</option>
+            <option value="supplier">Supplier</option>
+            <option value="both">Both</option>
+          </select>
+        </div>
+        {isAdmin && <button onClick={openNew}>New Partner</button>}
+      </div>
+      {isLoading && <div>Loading...</div>}
+      {isError && <div>Error loading partners</div>}
+      {!isLoading && data && (
+        <>
+          <table border={1} cellPadding={4} cellSpacing={0} style={{ width: '100%' }}>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Type</th>
+                <th>Email</th>
+                <th>Phone</th>
+                <th>Tax Number</th>
+                <th>Active</th>
+                <th>Created</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.items.map((p: Partner) => (
+                <tr key={p.id}>
+                  <td>{p.name}</td>
+                  <td>{p.type}</td>
+                  <td>{p.email ?? '-'}</td>
+                  <td>{p.phone ?? '-'}</td>
+                  <td>{p.tax_number ?? '-'}</td>
+                  <td>{p.is_active ? 'Yes' : 'No'}</td>
+                  <td>{p.created_at_utc}</td>
+                  <td>
+                    <button onClick={() => alert(JSON.stringify(p, null, 2))}>View</button>
+                    {isAdmin && (
+                      <>
+                        <button onClick={() => openEdit(p)}>Edit</button>
+                        <ConfirmDialog
+                          message="Delete this partner?"
+                          onConfirm={() => handleDelete(p.id)}
+                        >
+                          <button>Delete</button>
+                        </ConfirmDialog>
+                      </>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              marginTop: '1rem',
+            }}
+          >
+            <div>
+              <button disabled={page === 1} onClick={() => setPage((p) => p - 1)}>
+                Prev
+              </button>
+              <span style={{ margin: '0 0.5rem' }}>{page}</span>
+              <button
+                disabled={page * pageSize >= data.total}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                Next
+              </button>
+            </div>
+            <div>
+              <select
+                value={pageSize}
+                onChange={(e) => {
+                  setPageSize(Number(e.target.value))
+                  setPage(1)
+                }}
+              >
+                <option value={10}>10</option>
+                <option value={20}>20</option>
+                <option value={50}>50</option>
+              </select>
+            </div>
+            <div>Total: {data.total}</div>
+          </div>
+        </>
+      )}
+      {showForm && (
+        <div
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            background: 'rgba(0,0,0,0.3)',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        >
+          <div style={{ background: '#fff', padding: '1rem', minWidth: 300 }}>
+            <PartnerForm
+              mode={editing ? 'edit' : 'create'}
+              initial={editing || undefined}
+              onSubmit={handleSubmit}
+              onCancel={() => setShowForm(false)}
+              error={formError || undefined}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default Partners
+

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -4,6 +4,7 @@ import Login from './pages/Login'
 import Dashboard from './pages/Dashboard'
 import Layout from './components/Layout'
 import Products from './pages/Products'
+import Partners from './pages/Partners'
 
 const PrivateRoute = ({ children }: { children: JSX.Element }) => {
   const { token } = useAuth()
@@ -34,6 +35,16 @@ export const AppRoutes = () => (
         <PrivateRoute>
           <Layout>
             <Products />
+          </Layout>
+        </PrivateRoute>
+      }
+    />
+    <Route
+      path="/partners"
+      element={
+        <PrivateRoute>
+          <Layout>
+            <Partners />
           </Layout>
         </PrivateRoute>
       }

--- a/web/src/types/partner.ts
+++ b/web/src/types/partner.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod'
+
+export const partnerSchema = z.object({
+  id: z.string(),
+  name: z.string().min(2).max(120),
+  type: z.enum(['customer', 'supplier', 'both']),
+  email: z.string().email().optional(),
+  phone: z.string().min(5).optional(),
+  tax_number: z.string().min(5).max(20).optional(),
+  billing_address: z.string().optional(),
+  shipping_address: z.string().optional(),
+  is_active: z.boolean(),
+  created_at_utc: z.string(),
+})
+
+export type Partner = z.infer<typeof partnerSchema>
+
+export const partnerCreateSchema = partnerSchema
+  .omit({ id: true, created_at_utc: true })
+  .extend({
+    is_active: z.boolean().optional(),
+  })
+
+export type PartnerCreate = z.infer<typeof partnerCreateSchema>
+
+export const partnerUpdateSchema = partnerCreateSchema.partial()
+export type PartnerUpdate = z.infer<typeof partnerUpdateSchema>
+


### PR DESCRIPTION
## Summary
- add Partner types and API hooks
- implement partners list with search, type filter, pagination and form
- document partners page access and permissions

## Testing
- `npm run build` *(fails: Cannot find module 'react' etc. - dependencies missing)*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3923521c832da488c14fafcffd62