### PR TITLE
feat(web): add sales quotes management UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,3 +159,4 @@ Lokal makinede `alembic upgrade head` veya `pytest` çalıştırmayın.
 4. `npm run dev`
 5. Login: `admin@example.com` / `ChangeMe123!`
 6. Giriş yaptıktan sonra sidebar'dan **Products** veya **Partners** linklerine tıklayarak listeleri görüntüleyebilirsiniz. Partners sayfasında arama kutusu, type filtresi ve sayfalama bulunur. Admin rolünde olmayan kullanıcılar bu sayfada yalnızca listeyi görüntüler.
+7. **Sales > Quotes** ekranında teklifleri arama, durum ve partner filtresiyle listeleyebilir; admin kullanıcılar yeni teklif oluşturup yalnızca `DRAFT` durumundakileri düzenleyebilir. Durum menüsünden `SENT`, `APPROVED`, `REJECTED` veya `EXPIRED` seçenekleri uygulanabilir. `APPROVED` veya `SENT` durumundaki teklifler "Convert to Order" ile satış siparişine çevrilir.

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -19,7 +19,7 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
           <NavLink to="/dashboard">Dashboard</NavLink>
           <NavLink to="/products">Products</NavLink>
           <NavLink to="/partners">Partners</NavLink>
-          <NavLink to="/sales/quotes">Sales</NavLink>
+          <NavLink to="/sales/quotes">Sales &gt; Quotes</NavLink>
         </nav>
       </aside>
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>

--- a/web/src/components/QuoteForm.tsx
+++ b/web/src/components/QuoteForm.tsx
@@ -1,0 +1,285 @@
+import React, { useState } from 'react'
+import {
+  quoteCreateSchema,
+  quoteUpdateSchema,
+  QuoteDetail,
+  QuoteCreate,
+  QuoteUpdate,
+  QuoteItemIn,
+} from '../types/quote'
+import { listPartners } from '../lib/partners'
+import { listProducts } from '../lib/products'
+
+interface Props {
+  mode: 'create' | 'edit'
+  initial?: QuoteDetail
+  onSubmit: (data: QuoteCreate | QuoteUpdate) => void
+  onCancel: () => void
+  error?: string
+}
+
+const emptyItem: QuoteItemIn = {
+  product_id: '',
+  description: '',
+  quantity: 1,
+  unit_price: 0,
+  line_discount_rate: 0,
+  tax_rate: 0,
+}
+
+const QuoteForm: React.FC<Props> = ({ mode, initial, onSubmit, onCancel, error }) => {
+  const [form, setForm] = useState({
+    partner_id: initial?.partner_id || '',
+    currency: initial?.currency || 'USD',
+    issue_date: initial?.issue_date || new Date().toISOString().slice(0, 10),
+    valid_until: initial?.valid_until || '',
+    notes: initial?.notes || '',
+    discount_rate: initial?.discount_rate ?? 0,
+    items:
+      initial?.items?.map((i) => ({
+        product_id: i.product_id,
+        description: i.description || '',
+        quantity: i.quantity,
+        unit_price: i.unit_price,
+        line_discount_rate: i.line_discount_rate || 0,
+        tax_rate: i.tax_rate || 0,
+      })) || [emptyItem],
+  })
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  const partnersQuery = listPartners({ search: '', type: '', page: 1, pageSize: 50 })
+  const productsQuery = listProducts({ search: '', page: 1, pageSize: 50 })
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target
+    setForm((f) => ({ ...f, [name]: value }))
+  }
+
+  const handleItemChange = (
+    index: number,
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const { name, value } = e.target
+    setForm((f) => {
+      const items = [...f.items]
+      ;(items[index] as any)[name] = value
+      return { ...f, items }
+    })
+  }
+
+  const addItem = () => {
+    setForm((f) => ({ ...f, items: [...f.items, { ...emptyItem }] }))
+  }
+
+  const removeItem = (idx: number) => {
+    setForm((f) => ({ ...f, items: f.items.filter((_, i) => i !== idx) }))
+  }
+
+  const calcLine = (item: QuoteItemIn) => {
+    const qty = Number(item.quantity) || 0
+    const price = Number(item.unit_price) || 0
+    const ldisc = Number(item.line_discount_rate) || 0
+    const tax = Number(item.tax_rate) || 0
+    const lineSubtotal = qty * price * (1 - ldisc / 100)
+    const lineTax = lineSubtotal * (tax / 100)
+    const lineTotal = lineSubtotal + lineTax
+    return { lineSubtotal, lineTax, lineTotal }
+  }
+
+  const totals = form.items.reduce(
+    (acc, it) => {
+      const { lineSubtotal, lineTax } = calcLine(it)
+      acc.subtotal += lineSubtotal
+      acc.tax_total += lineTax
+      return acc
+    },
+    { subtotal: 0, tax_total: 0 }
+  )
+  const discounted = totals.subtotal * (1 - Number(form.discount_rate || 0) / 100)
+  const grand = discounted + totals.tax_total
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const schema = mode === 'edit' ? quoteUpdateSchema : quoteCreateSchema
+    const payload = {
+      ...form,
+      discount_rate: Number(form.discount_rate) || 0,
+      items: form.items.map((it) => ({
+        ...it,
+        quantity: Number(it.quantity),
+        unit_price: Number(it.unit_price),
+        line_discount_rate: it.line_discount_rate ? Number(it.line_discount_rate) : undefined,
+        tax_rate: it.tax_rate ? Number(it.tax_rate) : undefined,
+      })),
+    }
+    const parsed = schema.safeParse(payload)
+    if (!parsed.success) {
+      const errs: Record<string, string> = {}
+      parsed.error.errors.forEach((er) => {
+        const key = er.path[0] as string
+        errs[key] = er.message
+      })
+      setErrors(errs)
+      return
+    }
+    setErrors({})
+    onSubmit(parsed.data)
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', maxHeight: '80vh', overflowY: 'auto' }}
+    >
+      {error && <div style={{ color: 'red' }}>{error}</div>}
+      <label>
+        Partner
+        <select name="partner_id" value={form.partner_id} onChange={handleChange}>
+          <option value="">Select...</option>
+          {partnersQuery.data?.items.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+        {errors.partner_id && <span style={{ color: 'red' }}>{errors.partner_id}</span>}
+      </label>
+      <label>
+        Currency
+        <select name="currency" value={form.currency} onChange={handleChange}>
+          <option value="USD">USD</option>
+          <option value="EUR">EUR</option>
+          <option value="TRY">TRY</option>
+        </select>
+      </label>
+      <label>
+        Issue Date
+        <input name="issue_date" type="date" value={form.issue_date} onChange={handleChange} />
+        {errors.issue_date && <span style={{ color: 'red' }}>{errors.issue_date}</span>}
+      </label>
+      <label>
+        Valid Until
+        <input name="valid_until" type="date" value={form.valid_until} onChange={handleChange} />
+      </label>
+      <label>
+        Notes
+        <input name="notes" value={form.notes} onChange={handleChange} />
+      </label>
+      <label>
+        Discount Rate (%)
+        <input
+          name="discount_rate"
+          type="number"
+          value={form.discount_rate}
+          onChange={handleChange}
+        />
+        {errors.discount_rate && (
+          <span style={{ color: 'red' }}>{errors.discount_rate}</span>
+        )}
+      </label>
+      <table border={1} cellPadding={4} cellSpacing={0} style={{ width: '100%' }}>
+        <thead>
+          <tr>
+            <th>Product</th>
+            <th>Description</th>
+            <th>Qty</th>
+            <th>Unit Price</th>
+            <th>Line Disc %</th>
+            <th>Tax %</th>
+            <th>Subtotal</th>
+            <th>Tax</th>
+            <th>Total</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {form.items.map((it, idx) => {
+            const { lineSubtotal, lineTax, lineTotal } = calcLine(it)
+            return (
+              <tr key={idx}>
+                <td>
+                  <select
+                    name="product_id"
+                    value={it.product_id}
+                    onChange={(e) => handleItemChange(idx, e)}
+                  >
+                    <option value="">Select...</option>
+                    {productsQuery.data?.items.map((p) => (
+                      <option key={p.id} value={p.id}>
+                        {p.name}
+                      </option>
+                    ))}
+                  </select>
+                </td>
+                <td>
+                  <input
+                    name="description"
+                    value={it.description || ''}
+                    onChange={(e) => handleItemChange(idx, e)}
+                  />
+                </td>
+                <td>
+                  <input
+                    name="quantity"
+                    type="number"
+                    value={it.quantity}
+                    onChange={(e) => handleItemChange(idx, e)}
+                  />
+                </td>
+                <td>
+                  <input
+                    name="unit_price"
+                    type="number"
+                    value={it.unit_price}
+                    onChange={(e) => handleItemChange(idx, e)}
+                  />
+                </td>
+                <td>
+                  <input
+                    name="line_discount_rate"
+                    type="number"
+                    value={it.line_discount_rate}
+                    onChange={(e) => handleItemChange(idx, e)}
+                  />
+                </td>
+                <td>
+                  <input
+                    name="tax_rate"
+                    type="number"
+                    value={it.tax_rate}
+                    onChange={(e) => handleItemChange(idx, e)}
+                  />
+                </td>
+                <td>{lineSubtotal.toFixed(2)}</td>
+                <td>{lineTax.toFixed(2)}</td>
+                <td>{lineTotal.toFixed(2)}</td>
+                <td>
+                  <button type="button" onClick={() => removeItem(idx)}>
+                    Remove
+                  </button>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      <button type="button" onClick={addItem} style={{ width: 'fit-content' }}>
+        Add line
+      </button>
+      <div style={{ alignSelf: 'flex-end', marginTop: '1rem' }}>
+        <div>Subtotal: {totals.subtotal.toFixed(2)}</div>
+        <div>Tax Total: {totals.tax_total.toFixed(2)}</div>
+        <div>Grand Total: {grand.toFixed(2)}</div>
+      </div>
+      <div style={{ display: 'flex', gap: '0.5rem' }}>
+        <button type="submit">{mode === 'create' ? 'Create' : 'Update'}</button>
+        <button type="button" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  )
+}
+
+export default QuoteForm
+

--- a/web/src/components/StatusBadge.tsx
+++ b/web/src/components/StatusBadge.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { Quote } from '../types/quote'
+
+const colors: Record<Quote['status'], string> = {
+  DRAFT: '#999',
+  SENT: '#0af',
+  APPROVED: 'green',
+  REJECTED: 'red',
+  EXPIRED: 'orange',
+}
+
+const StatusBadge: React.FC<{ status: Quote['status'] }> = ({ status }) => (
+  <span
+    style={{
+      padding: '0.2rem 0.5rem',
+      borderRadius: 4,
+      background: colors[status],
+      color: '#fff',
+      fontSize: '0.8rem',
+    }}
+  >
+    {status}
+  </span>
+)
+
+export default StatusBadge
+

--- a/web/src/lib/quotes.ts
+++ b/web/src/lib/quotes.ts
@@ -1,0 +1,84 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import api from './api'
+import { Quote, QuoteDetail, QuoteCreate, QuoteUpdate } from '../types/quote'
+
+interface ListParams {
+  search: string
+  status: string
+  partnerId: string
+  page: number
+  pageSize: number
+}
+
+export const listQuotes = ({ search, status, partnerId, page, pageSize }: ListParams) =>
+  useQuery({
+    queryKey: ['quotes', { search, status, partnerId, page, pageSize }],
+    queryFn: async () => {
+      const res = await api.get('/sales/quotes', {
+        params: { search, status, partner_id: partnerId, page, page_size: pageSize },
+      })
+      return res.data as {
+        items: Quote[]
+        total: number
+        page: number
+        page_size: number
+      }
+    },
+  })
+
+export const getQuote = (id: string) =>
+  useQuery({
+    queryKey: ['quotes', id],
+    queryFn: async () => {
+      const res = await api.get(`/sales/quotes/${id}`)
+      return res.data as QuoteDetail
+    },
+    enabled: !!id,
+  })
+
+export const createQuote = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (payload: QuoteCreate) =>
+      api.post('/sales/quotes', payload).then((res) => res.data as QuoteDetail),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['quotes'] })
+    },
+  })
+}
+
+export const updateQuote = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: QuoteUpdate }) =>
+      api.put(`/sales/quotes/${id}`, payload).then((res) => res.data as QuoteDetail),
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({ queryKey: ['quotes'] })
+      queryClient.invalidateQueries({ queryKey: ['quotes', vars.id] })
+    },
+  })
+}
+
+export const setQuoteStatus = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, status }: { id: string; status: string }) =>
+      api.post(`/sales/quotes/${id}/status`, { status }).then((res) => res.data as QuoteDetail),
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({ queryKey: ['quotes'] })
+      queryClient.invalidateQueries({ queryKey: ['quotes', vars.id] })
+    },
+  })
+}
+
+export const convertQuoteToOrder = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) =>
+      api.post(`/sales/quotes/${id}/to-order`).then((res) => res.data as any),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['quotes'] })
+    },
+  })
+}
+

--- a/web/src/pages/SalesQuotes.tsx
+++ b/web/src/pages/SalesQuotes.tsx
@@ -1,0 +1,266 @@
+import React, { useState, useEffect } from 'react'
+import { useAuth } from '../store/auth'
+import {
+  listQuotes,
+  createQuote,
+  updateQuote,
+  setQuoteStatus,
+  convertQuoteToOrder,
+  getQuote,
+} from '../lib/quotes'
+import { listPartners } from '../lib/partners'
+import QuoteForm from '../components/QuoteForm'
+import StatusBadge from '../components/StatusBadge'
+import { Quote } from '../types/quote'
+
+const statusOptions: Record<string, string[]> = {
+  DRAFT: ['SENT'],
+  SENT: ['APPROVED', 'REJECTED', 'EXPIRED'],
+  APPROVED: ['REJECTED', 'EXPIRED'],
+  REJECTED: [],
+  EXPIRED: [],
+}
+
+const SalesQuotes: React.FC = () => {
+  const { currentUser } = useAuth()
+  const isAdmin = currentUser?.role === 'admin'
+
+  const [searchInput, setSearchInput] = useState('')
+  const [search, setSearch] = useState('')
+  const [status, setStatus] = useState('')
+  const [partnerInput, setPartnerInput] = useState('')
+  const [partnerSearch, setPartnerSearch] = useState('')
+  const [partnerId, setPartnerId] = useState('')
+  const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState(10)
+  const [showForm, setShowForm] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [formError, setFormError] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setSearch(searchInput)
+      setPage(1)
+    }, 300)
+    return () => clearTimeout(t)
+  }, [searchInput])
+
+  useEffect(() => {
+    const t = setTimeout(() => setPartnerSearch(partnerInput), 300)
+    return () => clearTimeout(t)
+  }, [partnerInput])
+
+  const quotesQuery = listQuotes({ search, status, partnerId, page, pageSize })
+  const partnersQuery = listPartners({ search: partnerSearch, type: '', page: 1, pageSize: 20 })
+
+  useEffect(() => {
+    const found = partnersQuery.data?.items.find((p) => p.name === partnerInput)
+    setPartnerId(found ? found.id : '')
+    setPage(1)
+  }, [partnerInput, partnersQuery.data])
+
+  const createMutation = createQuote()
+  const updateMutation = updateQuote()
+  const statusMutation = setQuoteStatus()
+  const convertMutation = convertQuoteToOrder()
+
+  const openNew = () => {
+    setEditingId(null)
+    setFormError(null)
+    setShowForm(true)
+  }
+
+  const openEdit = (id: string) => {
+    setEditingId(id)
+    setFormError(null)
+    setShowForm(true)
+  }
+
+  const handleSubmit = async (payload: any) => {
+    try {
+      if (editingId) {
+        await updateMutation.mutateAsync({ id: editingId, payload })
+      } else {
+        await createMutation.mutateAsync(payload)
+      }
+      setShowForm(false)
+    } catch (err: any) {
+      setFormError(err.response?.data?.detail || 'Error')
+    }
+  }
+
+  const handleStatusChange = async (id: string, newStatus: string) => {
+    try {
+      await statusMutation.mutateAsync({ id, status: newStatus })
+    } catch (err: any) {
+      setActionError(err.response?.data?.detail || 'Error')
+    }
+  }
+
+  const handleConvert = async (id: string) => {
+    try {
+      const res = await convertMutation.mutateAsync(id)
+      alert(`Converted to order: ${res.id}`)
+    } catch (err: any) {
+      setActionError(err.response?.data?.detail || 'Error')
+    }
+  }
+
+  const quoteDetail = getQuote(editingId || '')
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <div
+        style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '1rem', gap: '0.5rem' }}
+      >
+        <input
+          placeholder="Search"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+        />
+        <select value={status} onChange={(e) => { setStatus(e.target.value); setPage(1) }}>
+          <option value="">All</option>
+          <option value="DRAFT">DRAFT</option>
+          <option value="SENT">SENT</option>
+          <option value="APPROVED">APPROVED</option>
+          <option value="REJECTED">REJECTED</option>
+          <option value="EXPIRED">EXPIRED</option>
+        </select>
+        <input
+          list="partner-options"
+          placeholder="Partner"
+          value={partnerInput}
+          onChange={(e) => setPartnerInput(e.target.value)}
+        />
+        <datalist id="partner-options">
+          {partnersQuery.data?.items.map((p) => (
+            <option key={p.id} value={p.name} />
+          ))}
+        </datalist>
+        {isAdmin && <button onClick={openNew}>New Quote</button>}
+      </div>
+      {actionError && <div style={{ color: 'red' }}>{actionError}</div>}
+      {quotesQuery.isLoading && <div>Loading...</div>}
+      {quotesQuery.isError && <div>Error loading quotes</div>}
+      {!quotesQuery.isLoading && quotesQuery.data && (
+        <>
+          <table border={1} cellPadding={4} cellSpacing={0} style={{ width: '100%' }}>
+            <thead>
+              <tr>
+                <th>Number</th>
+                <th>Partner</th>
+                <th>Status</th>
+                <th>Issue Date</th>
+                <th>Grand Total</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {quotesQuery.data.items.map((q: Quote) => (
+                <tr key={q.id}>
+                  <td>{q.number}</td>
+                  <td>{q.partner_id}</td>
+                  <td>
+                    <StatusBadge status={q.status} />
+                  </td>
+                  <td>{q.issue_date}</td>
+                  <td>{q.grand_total}</td>
+                  <td>
+                    <button onClick={() => alert(JSON.stringify(q, null, 2))}>View</button>
+                    {isAdmin && q.status === 'DRAFT' && (
+                      <button onClick={() => openEdit(q.id)}>Edit</button>
+                    )}
+                    {isAdmin && statusOptions[q.status].length > 0 && (
+                      <select
+                        defaultValue=""
+                        onChange={(e) => {
+                          if (e.target.value) handleStatusChange(q.id, e.target.value)
+                        }}
+                      >
+                        <option value="">Status</option>
+                        {statusOptions[q.status].map((s) => (
+                          <option key={s} value={s}>
+                            {s}
+                          </option>
+                        ))}
+                      </select>
+                    )}
+                    {isAdmin && ['APPROVED', 'SENT'].includes(q.status) && (
+                      <button onClick={() => handleConvert(q.id)}>To Order</button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              marginTop: '1rem',
+            }}
+          >
+            <div>
+              <button disabled={page === 1} onClick={() => setPage((p) => p - 1)}>
+                Prev
+              </button>
+              <span style={{ margin: '0 0.5rem' }}>{page}</span>
+              <button
+                disabled={page * pageSize >= quotesQuery.data.total}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                Next
+              </button>
+            </div>
+            <div>
+              <select
+                value={pageSize}
+                onChange={(e) => {
+                  setPageSize(Number(e.target.value))
+                  setPage(1)
+                }}
+              >
+                <option value={10}>10</option>
+                <option value={20}>20</option>
+                <option value={50}>50</option>
+              </select>
+            </div>
+            <div>Total: {quotesQuery.data.total}</div>
+          </div>
+        </>
+      )}
+      {showForm && (
+        <div
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            background: 'rgba(0,0,0,0.3)',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        >
+          <div style={{ background: '#fff', padding: '1rem', minWidth: 400 }}>
+            {editingId && quoteDetail.isLoading && <div>Loading...</div>}
+            {(!editingId || quoteDetail.data) && (
+              <QuoteForm
+                mode={editingId ? 'edit' : 'create'}
+                initial={editingId ? quoteDetail.data : undefined}
+                onSubmit={handleSubmit}
+                onCancel={() => setShowForm(false)}
+                error={formError || undefined}
+              />
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default SalesQuotes
+

--- a/web/src/routes.tsx
+++ b/web/src/routes.tsx
@@ -5,6 +5,7 @@ import Dashboard from './pages/Dashboard'
 import Layout from './components/Layout'
 import Products from './pages/Products'
 import Partners from './pages/Partners'
+import SalesQuotes from './pages/SalesQuotes'
 
 const PrivateRoute = ({ children }: { children: JSX.Element }) => {
   const { token } = useAuth()
@@ -45,6 +46,16 @@ export const AppRoutes = () => (
         <PrivateRoute>
           <Layout>
             <Partners />
+          </Layout>
+        </PrivateRoute>
+      }
+    />
+    <Route
+      path="/sales/quotes"
+      element={
+        <PrivateRoute>
+          <Layout>
+            <SalesQuotes />
           </Layout>
         </PrivateRoute>
       }

--- a/web/src/types/quote.ts
+++ b/web/src/types/quote.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod'
+
+export const quoteItemInSchema = z.object({
+  product_id: z.string(),
+  description: z.string().optional(),
+  quantity: z.number().gt(0),
+  unit_price: z.number().min(0),
+  line_discount_rate: z.number().min(0).max(100).optional(),
+  tax_rate: z.number().min(0).max(100).optional(),
+})
+
+export type QuoteItemIn = z.infer<typeof quoteItemInSchema>
+
+export const quoteSchema = z.object({
+  id: z.string(),
+  number: z.string(),
+  partner_id: z.string(),
+  currency: z.string(),
+  status: z.enum(['DRAFT', 'SENT', 'APPROVED', 'REJECTED', 'EXPIRED']),
+  issue_date: z.string(),
+  valid_until: z.string().optional(),
+  notes: z.string().optional(),
+  discount_rate: z.number().min(0).max(100),
+  subtotal: z.number(),
+  tax_total: z.number(),
+  grand_total: z.number(),
+  created_at_utc: z.string(),
+})
+
+export type Quote = z.infer<typeof quoteSchema>
+
+export const quoteDetailSchema = quoteSchema.extend({
+  items: z
+    .array(
+      quoteItemInSchema.extend({
+        line_subtotal: z.number(),
+        line_tax: z.number(),
+        line_total: z.number(),
+      })
+    )
+    .min(1),
+})
+
+export type QuoteDetail = z.infer<typeof quoteDetailSchema>
+
+export const quoteCreateSchema = z.object({
+  partner_id: z.string(),
+  currency: z.string(),
+  issue_date: z.string(),
+  valid_until: z.string().optional(),
+  notes: z.string().optional(),
+  discount_rate: z.number().min(0).max(100).default(0),
+  items: z.array(quoteItemInSchema).min(1),
+})
+
+export type QuoteCreate = z.infer<typeof quoteCreateSchema>
+
+export const quoteUpdateSchema = quoteCreateSchema
+export type QuoteUpdate = z.infer<typeof quoteUpdateSchema>
+


### PR DESCRIPTION
## Summary
- add quote types and query hooks
- implement Sales Quotes page with filter, status change, and convert-to-order
- provide QuoteForm component with totals and status badge

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: 403 Forbidden fetching packages)*
- `npm run build` *(fails: Cannot find module 'react-router-dom' due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3a5d6b6c832dbce3a68386d5ac10