### PR TITLE
Add HR employees module with search and RBAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,19 @@
 16. Dashboard özeti:
    `curl -s http://localhost:8000/dashboard/summary -H "Authorization: Bearer $TOKEN"`
 
+17. Çalışan CRUD örnekleri:
+   `curl -s -X POST http://localhost:8000/hr/employees \
+     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+     -d '{"code":"P0001","first_name":"Ada","last_name":"Lovelace"}'`
+   `curl -s http://localhost:8000/hr/employees -H "Authorization: Bearer $TOKEN"`
+   `EMP_ID=<dönen_id>`
+   `curl -s http://localhost:8000/hr/employees/$EMP_ID -H "Authorization: Bearer $TOKEN"`
+   `curl -s -X PUT http://localhost:8000/hr/employees/$EMP_ID \
+     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+     -d '{"title":"Lead"}'`
+   `curl -s -X DELETE http://localhost:8000/hr/employees/$EMP_ID \
+     -H "Authorization: Bearer $TOKEN"`
+
 ## Cari Hesap Akışı
 
 1. Fatura `ISSUED` olduğunda otomatik olarak `ar_entries` tablosuna borç kaydı düşer.

--- a/backend/alembic/versions/0012_create_employees.py
+++ b/backend/alembic/versions/0012_create_employees.py
@@ -1,0 +1,74 @@
+"""create employees table"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0012"
+down_revision = "0011"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        op.execute('CREATE EXTENSION IF NOT EXISTS "pgcrypto";')
+        op.execute('CREATE EXTENSION IF NOT EXISTS "citext";')
+    op.create_table(
+        "employees",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("code", sa.Text(), nullable=False, unique=True),
+        sa.Column("first_name", sa.Text(), nullable=False),
+        sa.Column("last_name", sa.Text(), nullable=False),
+        sa.Column(
+            "full_name",
+            sa.Text(),
+            sa.Computed("first_name || ' ' || last_name", persisted=True),
+        ),
+        sa.Column("email", postgresql.CITEXT(), nullable=True, unique=True),
+        sa.Column("phone", sa.Text(), nullable=True),
+        sa.Column("department", sa.Text(), nullable=True),
+        sa.Column("title", sa.Text(), nullable=True),
+        sa.Column(
+            "start_date",
+            sa.Date(),
+            nullable=False,
+            server_default=sa.text("CURRENT_DATE"),
+        ),
+        sa.Column("end_date", sa.Date(), nullable=True),
+        sa.Column(
+            "is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")
+        ),
+        sa.Column(
+            "annual_leave_days_per_year",
+            sa.Numeric(5, 2),
+            nullable=False,
+            server_default=sa.text("14.00"),
+        ),
+        sa.Column(
+            "created_at_utc",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_employees_created",
+        "employees",
+        [sa.text("created_at_utc DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_employees_created", table_name="employees")
+    op.drop_table("employees")
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        op.execute('DROP EXTENSION IF EXISTS "citext";')
+        op.execute('DROP EXTENSION IF EXISTS "pgcrypto";')

--- a/backend/app/api/employees.py
+++ b/backend/app/api/employees.py
@@ -1,0 +1,105 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.deps import (
+    get_current_admin,
+    get_current_user,
+    get_db,
+    get_pagination,
+)
+from app.models.user import User
+from app.schemas.employee import (
+    EmployeeCreate,
+    EmployeeListResponse,
+    EmployeePublic,
+    EmployeeUpdate,
+)
+from app.services.employee_service import (
+    create_employee,
+    delete_employee,
+    get_employee,
+    list_employees,
+    update_employee,
+)
+
+router = APIRouter(prefix="/hr/employees", tags=["hr-employees"])
+
+
+@router.get("", response_model=EmployeeListResponse)
+def list_employees_endpoint(
+    pagination: tuple[int, int] = Depends(get_pagination),
+    search: str | None = None,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    page, page_size = pagination
+    items, total = list_employees(db, page, page_size, search)
+    return {"items": items, "total": total, "page": page, "page_size": page_size}
+
+
+@router.get("/{employee_id}", response_model=EmployeePublic)
+def get_employee_endpoint(
+    employee_id: UUID,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    employee = get_employee(db, employee_id)
+    if not employee:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Employee not found"
+        )
+    return employee
+
+
+@router.post("", response_model=EmployeePublic, status_code=status.HTTP_201_CREATED)
+def create_employee_endpoint(
+    data: EmployeeCreate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    try:
+        employee = create_employee(db, data)
+    except IntegrityError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Employee with this code or email already exists",
+        )
+    return employee
+
+
+@router.put("/{employee_id}", response_model=EmployeePublic)
+def update_employee_endpoint(
+    employee_id: UUID,
+    data: EmployeeUpdate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    try:
+        employee = update_employee(db, employee_id, data)
+    except IntegrityError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Employee with this code or email already exists",
+        )
+    if not employee:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Employee not found"
+        )
+    return employee
+
+
+@router.delete("/{employee_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_employee_endpoint(
+    employee_id: UUID,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    deleted = delete_employee(db, employee_id)
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Employee not found"
+        )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,7 @@ from app.api.sales_orders import router as sales_orders_router
 from app.api.sales_invoices import router as sales_invoices_router
 from app.api.ar import router as ar_router
 from app.api.dashboard import router as dashboard_router
+from app.api.employees import router as employees_router
 from app.core.security import hash_password
 from app.core.config import settings
 from app.db.session import SessionLocal
@@ -50,3 +51,4 @@ app.include_router(sales_orders_router)
 app.include_router(sales_invoices_router)
 app.include_router(ar_router)
 app.include_router(dashboard_router)
+app.include_router(employees_router)

--- a/backend/app/models/employee.py
+++ b/backend/app/models/employee.py
@@ -1,0 +1,41 @@
+from sqlalchemy import (
+    Boolean,
+    Column,
+    Date,
+    DateTime,
+    Index,
+    Numeric,
+    Text,
+    func,
+    text,
+    Computed,
+)
+from sqlalchemy.dialects.postgresql import CITEXT, UUID
+
+from app.db.base import Base
+
+
+class Employee(Base):
+    __tablename__ = "employees"
+    __table_args__ = (Index("ix_employees_created", text("created_at_utc DESC")),)
+
+    id = Column(
+        UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()")
+    )
+    code = Column(Text, nullable=False, unique=True)
+    first_name = Column(Text, nullable=False)
+    last_name = Column(Text, nullable=False)
+    full_name = Column(Text, Computed("first_name || ' ' || last_name", persisted=True))
+    email = Column(CITEXT(), nullable=True, unique=True)
+    phone = Column(Text, nullable=True)
+    department = Column(Text, nullable=True)
+    title = Column(Text, nullable=True)
+    start_date = Column(Date, nullable=False, server_default=text("CURRENT_DATE"))
+    end_date = Column(Date, nullable=True)
+    is_active = Column(Boolean, nullable=False, server_default=text("true"))
+    annual_leave_days_per_year = Column(
+        Numeric(5, 2), nullable=False, server_default=text("14.00")
+    )
+    created_at_utc = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/backend/app/schemas/employee.py
+++ b/backend/app/schemas/employee.py
@@ -1,0 +1,62 @@
+from datetime import date, datetime
+from decimal import Decimal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+from app.schemas.common import PageMeta
+
+
+class EmployeeBase(BaseModel):
+    code: str = Field(..., pattern=r"^[A-Za-z0-9_-]{3,40}$")
+    first_name: str = Field(..., min_length=2, max_length=60)
+    last_name: str = Field(..., min_length=2, max_length=60)
+    email: EmailStr | None = None
+    phone: str | None = None
+    department: str | None = None
+    title: str | None = None
+    start_date: date | None = None
+    end_date: date | None = None
+    is_active: bool = True
+    annual_leave_days_per_year: Decimal = Decimal("14")
+
+
+class EmployeeCreate(EmployeeBase):
+    pass
+
+
+class EmployeeUpdate(BaseModel):
+    code: str | None = Field(None, pattern=r"^[A-Za-z0-9_-]{3,40}$")
+    first_name: str | None = Field(None, min_length=2, max_length=60)
+    last_name: str | None = Field(None, min_length=2, max_length=60)
+    email: EmailStr | None = None
+    phone: str | None = None
+    department: str | None = None
+    title: str | None = None
+    start_date: date | None = None
+    end_date: date | None = None
+    is_active: bool | None = None
+    annual_leave_days_per_year: Decimal | None = None
+
+
+class EmployeePublic(BaseModel):
+    id: UUID
+    code: str
+    first_name: str
+    last_name: str
+    full_name: str
+    email: EmailStr | None = None
+    phone: str | None = None
+    department: str | None = None
+    title: str | None = None
+    start_date: date
+    end_date: date | None = None
+    is_active: bool
+    annual_leave_days_per_year: Decimal
+    created_at_utc: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class EmployeeListResponse(PageMeta):
+    items: list[EmployeePublic]

--- a/backend/app/services/employee_service.py
+++ b/backend/app/services/employee_service.py
@@ -1,0 +1,72 @@
+from typing import Sequence
+from uuid import UUID
+
+from sqlalchemy import or_
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.employee import Employee
+from app.schemas.employee import EmployeeCreate, EmployeeUpdate
+
+
+def create_employee(db: Session, data: EmployeeCreate) -> Employee:
+    employee = Employee(**data.model_dump())
+    db.add(employee)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise
+    db.refresh(employee)
+    return employee
+
+
+def get_employee(db: Session, id: UUID) -> Employee | None:
+    return db.get(Employee, id)
+
+
+def list_employees(
+    db: Session, page: int, page_size: int, search: str | None = None
+) -> tuple[Sequence[Employee], int]:
+    query = db.query(Employee)
+    if search:
+        like = f"%{search}%"
+        query = query.filter(
+            or_(
+                Employee.code.ilike(like),
+                Employee.full_name.ilike(like),
+                Employee.email.ilike(like),
+            )
+        )
+    total = query.count()
+    items = (
+        query.order_by(Employee.created_at_utc.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+    return items, total
+
+
+def update_employee(db: Session, id: UUID, data: EmployeeUpdate) -> Employee | None:
+    employee = db.get(Employee, id)
+    if not employee:
+        return None
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(employee, field, value)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise
+    db.refresh(employee)
+    return employee
+
+
+def delete_employee(db: Session, id: UUID) -> bool:
+    employee = db.get(Employee, id)
+    if not employee:
+        return False
+    db.delete(employee)
+    db.commit()
+    return True

--- a/backend/tests/api/test_employees.py
+++ b/backend/tests/api/test_employees.py
@@ -1,0 +1,63 @@
+from app.db.session import SessionLocal
+from app.models.employee import Employee
+
+
+def seed_employee():
+    db = SessionLocal()
+    emp = Employee(code="E001", first_name="John", last_name="Doe")
+    db.add(emp)
+    db.commit()
+    db.close()
+
+
+def test_admin_can_create_and_get_employee(client, admin_token):
+    payload = {"code": "EMP1", "first_name": "Alice", "last_name": "Smith"}
+    res = client.post(
+        "/hr/employees",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=payload,
+    )
+    assert res.status_code == 201
+    emp_id = res.json()["id"]
+    res_get = client.get(
+        f"/hr/employees/{emp_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert res_get.status_code == 200
+    assert res_get.json()["id"] == emp_id
+
+
+def test_list_employees(client, admin_token):
+    seed_employee()
+    res = client.get(
+        "/hr/employees",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["total"] >= 1
+
+
+def test_user_cannot_create_employee(client, user_token):
+    payload = {"code": "USR1", "first_name": "Bob", "last_name": "Jones"}
+    res = client.post(
+        "/hr/employees",
+        headers={"Authorization": f"Bearer {user_token}"},
+        json=payload,
+    )
+    assert res.status_code == 403
+
+
+def test_duplicate_code_conflict(client, admin_token):
+    payload = {"code": "DUP1", "first_name": "Ann", "last_name": "Brown"}
+    res1 = client.post(
+        "/hr/employees",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=payload,
+    )
+    assert res1.status_code == 201
+    res2 = client.post(
+        "/hr/employees",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json=payload,
+    )
+    assert res2.status_code == 409


### PR DESCRIPTION
## Summary
- add alembic migration for employees table
- implement Employee model, schemas, service and API with RBAC
- wire employees router and document curl examples
- add placeholder API tests for employees

## Testing
- `ruff app/models/employee.py app/schemas/employee.py app/services/employee_service.py app/api/employees.py app/main.py tests/api/test_employees.py`
- `alembic upgrade head` *(fails: ValidationError: Settings missing DATABASE_URL, SECRET_KEY, ADMIN_EMAIL, ADMIN_PASSWORD)*
- `pytest -q` *(fails: IntegrityError: NOT NULL constraint failed on several tables)*

------
https://chatgpt.com/codex/tasks/task_e_68ac49f2e4b8832d835be090946fb97f