### PR TITLE
Add annual leave management module

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,22 @@
    `curl -s -X DELETE http://localhost:8000/hr/employees/$EMP_ID \
      -H "Authorization: Bearer $TOKEN"`
 
+18. İzin modülü örnekleri:
+   `curl -s -X POST http://localhost:8000/hr/leaves/types \\
+     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\
+     -d '{"code":"YILLIK","name":"Yıllık İzin","is_annual":true}'`
+   `curl -s -X POST http://localhost:8000/hr/leaves/requests \\
+     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\
+     -d '{"employee_id":"'$EMP_ID'","type_id":"<YILLIK_TYPE_ID>","start_date":"2024-01-10","end_date":"2024-01-12"}'`
+   `REQ_ID=<dönen_id>`
+   `curl -s -X POST http://localhost:8000/hr/leaves/requests/$REQ_ID/status \\
+     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\
+     -d '{"status":"SUBMITTED"}'`
+   `curl -s -X POST http://localhost:8000/hr/leaves/requests/$REQ_ID/status \\
+     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \\
+     -d '{"status":"APPROVED"}'`
+   `curl -s http://localhost:8000/hr/leaves/balance/$EMP_ID?year=2024 -H "Authorization: Bearer $TOKEN"`
+
 ## Cari Hesap Akışı
 
 1. Fatura `ISSUED` olduğunda otomatik olarak `ar_entries` tablosuna borç kaydı düşer.

--- a/backend/alembic/versions/0013_create_leave_tables.py
+++ b/backend/alembic/versions/0013_create_leave_tables.py
@@ -1,0 +1,108 @@
+"""create leave tables"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0013"
+down_revision = "0012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "leave_types",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("code", sa.Text(), nullable=False, unique=True),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column(
+            "is_annual",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "requires_approval",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "created_at_utc",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    op.create_table(
+        "leave_requests",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "employee_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("employees.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "type_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("leave_types.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "status",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'DRAFT'"),
+        ),
+        sa.Column("start_date", sa.Date(), nullable=False),
+        sa.Column("end_date", sa.Date(), nullable=False),
+        sa.Column(
+            "days",
+            sa.Numeric(6, 2),
+            nullable=False,
+            server_default=sa.text("0.00"),
+        ),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at_utc",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint(
+            "status IN ('DRAFT','SUBMITTED','APPROVED','REJECTED','CANCELLED')",
+            name="ck_leave_requests_status",
+        ),
+    )
+
+    op.create_index(
+        "ix_leave_requests_emp",
+        "leave_requests",
+        ["employee_id", "start_date", "end_date"],
+    )
+    op.create_index(
+        "ix_leave_requests_created",
+        "leave_requests",
+        [sa.text("created_at_utc DESC")],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_leave_requests_created", table_name="leave_requests")
+    op.drop_index("ix_leave_requests_emp", table_name="leave_requests")
+    op.drop_table("leave_requests")
+    op.drop_table("leave_types")

--- a/backend/app/api/leaves.py
+++ b/backend/app/api/leaves.py
@@ -1,0 +1,207 @@
+from datetime import date
+from typing import Literal
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+from pydantic import BaseModel
+
+from app.core.deps import (
+    get_current_admin,
+    get_current_user,
+    get_db,
+    get_pagination,
+)
+from app.models.user import User
+from app.schemas.leave import (
+    LeaveTypeCreate,
+    LeaveTypeUpdate,
+    LeaveTypeListResponse,
+    LeaveTypePublic,
+    LeaveRequestCreate,
+    LeaveRequestUpdate,
+    LeaveRequestListResponse,
+    LeaveRequestPublic,
+    AnnualBalance,
+)
+from app.services.leave_service import (
+    create_leave_type,
+    delete_leave_type,
+    list_leave_types,
+    update_leave_type,
+    create_leave_request,
+    get_leave_request,
+    list_leave_requests,
+    update_leave_request,
+    set_leave_status,
+    compute_employee_annual_balance,
+)
+
+
+class StatusChange(BaseModel):
+    status: Literal["SUBMITTED", "APPROVED", "REJECTED", "CANCELLED"]
+
+
+router = APIRouter(prefix="/hr/leaves", tags=["hr-leaves"])
+
+
+# Leave Types
+@router.get("/types", response_model=LeaveTypeListResponse)
+def list_leave_types_endpoint(
+    pagination: tuple[int, int] = Depends(get_pagination),
+    search: str | None = None,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    page, page_size = pagination
+    items, total = list_leave_types(db, page, page_size, search)
+    return {"items": items, "total": total, "page": page, "page_size": page_size}
+
+
+@router.post("/types", response_model=LeaveTypePublic, status_code=status.HTTP_201_CREATED)
+def create_leave_type_endpoint(
+    data: LeaveTypeCreate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    try:
+        lt = create_leave_type(db, data)
+    except IntegrityError:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="LeaveType with this code already exists")
+    return lt
+
+
+@router.put("/types/{type_id}", response_model=LeaveTypePublic)
+def update_leave_type_endpoint(
+    type_id: UUID,
+    data: LeaveTypeUpdate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    try:
+        lt = update_leave_type(db, type_id, data)
+    except IntegrityError:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="LeaveType with this code already exists")
+    if not lt:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="LeaveType not found")
+    return lt
+
+
+@router.delete("/types/{type_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_leave_type_endpoint(
+    type_id: UUID,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    deleted = delete_leave_type(db, type_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="LeaveType not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# Leave Requests
+@router.get("/requests", response_model=LeaveRequestListResponse)
+def list_leave_requests_endpoint(
+    pagination: tuple[int, int] = Depends(get_pagination),
+    employee_id: UUID | None = None,
+    status: str | None = None,
+    type_id: UUID | None = None,
+    date_from: date | None = Query(None, alias="from"),
+    date_to: date | None = Query(None, alias="to"),
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    page, page_size = pagination
+    items, total = list_leave_requests(
+        db,
+        page,
+        page_size,
+        employee_id=employee_id,
+        status=status,
+        type_id=type_id,
+        date_from=date_from,
+        date_to=date_to,
+    )
+    return {"items": items, "total": total, "page": page, "page_size": page_size}
+
+
+@router.get("/requests/{request_id}", response_model=LeaveRequestPublic)
+def get_leave_request_endpoint(
+    request_id: UUID,
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    req = get_leave_request(db, request_id)
+    if not req:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="LeaveRequest not found")
+    return req
+
+
+@router.post("/requests", response_model=LeaveRequestPublic, status_code=status.HTTP_201_CREATED)
+def create_leave_request_endpoint(
+    data: LeaveRequestCreate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    try:
+        req = create_leave_request(db, data)
+    except ValueError as e:
+        if str(e) == "invalid_dates":
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="invalid_dates")
+        if str(e) == "overlap":
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="overlap")
+        raise
+    return req
+
+
+@router.put("/requests/{request_id}", response_model=LeaveRequestPublic)
+def update_leave_request_endpoint(
+    request_id: UUID,
+    data: LeaveRequestUpdate,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    try:
+        req = update_leave_request(db, request_id, data)
+    except ValueError as e:
+        if str(e) == "immutable_state":
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="immutable_state")
+        if str(e) == "invalid_dates":
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="invalid_dates")
+        if str(e) == "overlap":
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="overlap")
+        raise
+    if not req:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="LeaveRequest not found")
+    return req
+
+
+@router.post("/requests/{request_id}/status", response_model=LeaveRequestPublic)
+def change_leave_status_endpoint(
+    request_id: UUID,
+    body: StatusChange,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    try:
+        req = set_leave_status(db, request_id, body.status)
+    except ValueError as e:
+        detail = str(e)
+        if detail in {"invalid_status", "insufficient_balance"}:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=detail)
+        raise
+    if not req:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="LeaveRequest not found")
+    return req
+
+
+@router.get("/balance/{employee_id}", response_model=AnnualBalance)
+def get_balance_endpoint(
+    employee_id: UUID,
+    year: int = Query(date.today().year, ge=2000),
+    db: Session = Depends(get_db),
+    user: User = Depends(get_current_user),
+):
+    balance = compute_employee_annual_balance(db, employee_id, year)
+    return balance

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -14,4 +14,7 @@ from app.models import (
     sales_order,
     sales_invoice,
     ar,
+    employee,
+    leave_type,
+    leave_request,
 )  # noqa: E402,F401

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from app.api.sales_invoices import router as sales_invoices_router
 from app.api.ar import router as ar_router
 from app.api.dashboard import router as dashboard_router
 from app.api.employees import router as employees_router
+from app.api.leaves import router as leaves_router
 from app.core.security import hash_password
 from app.core.config import settings
 from app.db.session import SessionLocal
@@ -52,3 +53,4 @@ app.include_router(sales_invoices_router)
 app.include_router(ar_router)
 app.include_router(dashboard_router)
 app.include_router(employees_router)
+app.include_router(leaves_router)

--- a/backend/app/models/leave_request.py
+++ b/backend/app/models/leave_request.py
@@ -1,0 +1,45 @@
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    Numeric,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.base import Base
+
+
+class LeaveRequest(Base):
+    __tablename__ = "leave_requests"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('DRAFT','SUBMITTED','APPROVED','REJECTED','CANCELLED')",
+            name="ck_leave_requests_status",
+        ),
+        Index("ix_leave_requests_emp", "employee_id", "start_date", "end_date"),
+        Index("ix_leave_requests_created", text("created_at_utc DESC")),
+    )
+
+    id = Column(
+        UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()")
+    )
+    employee_id = Column(
+        UUID(as_uuid=True), ForeignKey("employees.id", ondelete="RESTRICT"), nullable=False
+    )
+    type_id = Column(
+        UUID(as_uuid=True), ForeignKey("leave_types.id", ondelete="RESTRICT"), nullable=False
+    )
+    status = Column(Text, nullable=False, server_default=text("'DRAFT'"))
+    start_date = Column(Date, nullable=False)
+    end_date = Column(Date, nullable=False)
+    days = Column(Numeric(6, 2), nullable=False, server_default=text("0.00"))
+    reason = Column(Text, nullable=True)
+    created_at_utc = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/backend/app/models/leave_type.py
+++ b/backend/app/models/leave_type.py
@@ -1,0 +1,19 @@
+from sqlalchemy import Boolean, Column, DateTime, Text, func, text
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.base import Base
+
+
+class LeaveType(Base):
+    __tablename__ = "leave_types"
+
+    id = Column(
+        UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()")
+    )
+    code = Column(Text, nullable=False, unique=True)
+    name = Column(Text, nullable=False)
+    is_annual = Column(Boolean, nullable=False, server_default=text("false"))
+    requires_approval = Column(Boolean, nullable=False, server_default=text("true"))
+    created_at_utc = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/backend/app/schemas/leave.py
+++ b/backend/app/schemas/leave.py
@@ -1,0 +1,86 @@
+from datetime import date, datetime
+from decimal import Decimal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.common import PageMeta
+
+
+class LeaveTypeBase(BaseModel):
+    code: str = Field(..., pattern=r"^[A-Za-z0-9_-]{2,20}$")
+    name: str = Field(..., min_length=2, max_length=80)
+    is_annual: bool = False
+    requires_approval: bool = True
+
+
+class LeaveTypeCreate(LeaveTypeBase):
+    pass
+
+
+class LeaveTypeUpdate(BaseModel):
+    code: str | None = Field(None, pattern=r"^[A-Za-z0-9_-]{2,20}$")
+    name: str | None = Field(None, min_length=2, max_length=80)
+    is_annual: bool | None = None
+    requires_approval: bool | None = None
+
+
+class LeaveTypePublic(BaseModel):
+    id: UUID
+    code: str
+    name: str
+    is_annual: bool
+    requires_approval: bool
+    created_at_utc: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class LeaveTypeListResponse(PageMeta):
+    items: list[LeaveTypePublic]
+
+
+class LeaveRequestBase(BaseModel):
+    employee_id: UUID
+    type_id: UUID
+    start_date: date
+    end_date: date
+    reason: str | None = None
+
+
+class LeaveRequestCreate(LeaveRequestBase):
+    pass
+
+
+class LeaveRequestUpdate(BaseModel):
+    start_date: date | None = None
+    end_date: date | None = None
+    reason: str | None = None
+
+
+class LeaveRequestPublic(BaseModel):
+    id: UUID
+    employee_id: UUID
+    type_id: UUID
+    status: str
+    start_date: date
+    end_date: date
+    days: Decimal
+    reason: str | None = None
+    created_at_utc: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class LeaveRequestListResponse(PageMeta):
+    items: list[LeaveRequestPublic]
+
+
+class AnnualBalance(BaseModel):
+    employee_id: UUID
+    year: int
+    base: Decimal
+    used: Decimal
+    remaining: Decimal
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/leave_service.py
+++ b/backend/app/services/leave_service.py
@@ -1,0 +1,235 @@
+from datetime import date
+from decimal import Decimal
+from typing import Sequence
+from uuid import UUID
+
+from sqlalchemy import or_, func
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.leave_type import LeaveType
+from app.models.leave_request import LeaveRequest
+from app.schemas.leave import (
+    LeaveTypeCreate,
+    LeaveTypeUpdate,
+    LeaveRequestCreate,
+    LeaveRequestUpdate,
+)
+
+
+def _calc_days(start_date: date, end_date: date) -> Decimal:
+    if start_date > end_date:
+        raise ValueError("invalid_dates")
+    return Decimal((end_date - start_date).days + 1)
+
+
+def create_leave_type(db: Session, data: LeaveTypeCreate) -> LeaveType:
+    lt = LeaveType(**data.model_dump())
+    db.add(lt)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise
+    db.refresh(lt)
+    return lt
+
+
+def list_leave_types(
+    db: Session, page: int, page_size: int, search: str | None = None
+) -> tuple[Sequence[LeaveType], int]:
+    query = db.query(LeaveType)
+    if search:
+        like = f"%{search}%"
+        query = query.filter(or_(LeaveType.code.ilike(like), LeaveType.name.ilike(like)))
+    total = query.count()
+    items = (
+        query.order_by(LeaveType.created_at_utc.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+    return items, total
+
+
+def get_leave_type(db: Session, id: UUID) -> LeaveType | None:
+    return db.get(LeaveType, id)
+
+
+def update_leave_type(db: Session, id: UUID, data: LeaveTypeUpdate) -> LeaveType | None:
+    lt = db.get(LeaveType, id)
+    if not lt:
+        return None
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(lt, field, value)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise
+    db.refresh(lt)
+    return lt
+
+
+def delete_leave_type(db: Session, id: UUID) -> bool:
+    lt = db.get(LeaveType, id)
+    if not lt:
+        return False
+    db.delete(lt)
+    db.commit()
+    return True
+
+
+def create_leave_request(db: Session, data: LeaveRequestCreate) -> LeaveRequest:
+    days = _calc_days(data.start_date, data.end_date)
+    overlap = (
+        db.query(LeaveRequest)
+        .filter(
+            LeaveRequest.employee_id == data.employee_id,
+            LeaveRequest.status.in_(["SUBMITTED", "APPROVED"]),
+            LeaveRequest.start_date <= data.end_date,
+            LeaveRequest.end_date >= data.start_date,
+        )
+        .first()
+    )
+    if overlap:
+        raise ValueError("overlap")
+    req = LeaveRequest(
+        employee_id=data.employee_id,
+        type_id=data.type_id,
+        start_date=data.start_date,
+        end_date=data.end_date,
+        days=days,
+        reason=data.reason,
+    )
+    db.add(req)
+    db.commit()
+    db.refresh(req)
+    return req
+
+
+def get_leave_request(db: Session, id: UUID) -> LeaveRequest | None:
+    return db.get(LeaveRequest, id)
+
+
+def update_leave_request(
+    db: Session, id: UUID, data: LeaveRequestUpdate
+) -> LeaveRequest | None:
+    req = db.get(LeaveRequest, id)
+    if not req:
+        return None
+    if req.status != "DRAFT":
+        raise ValueError("immutable_state")
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(req, field, value)
+    if data.start_date is not None or data.end_date is not None:
+        req.days = _calc_days(req.start_date, req.end_date)
+        overlap = (
+            db.query(LeaveRequest)
+            .filter(
+                LeaveRequest.id != req.id,
+                LeaveRequest.employee_id == req.employee_id,
+                LeaveRequest.status.in_(["SUBMITTED", "APPROVED"]),
+                LeaveRequest.start_date <= req.end_date,
+                LeaveRequest.end_date >= req.start_date,
+            )
+            .first()
+        )
+        if overlap:
+            db.rollback()
+            # reset to original? but we already changed fields; easier to raise after rollback
+            raise ValueError("overlap")
+    db.commit()
+    db.refresh(req)
+    return req
+
+
+def _is_transition_allowed(current: str, new: str) -> bool:
+    transitions = {
+        "DRAFT": {"SUBMITTED", "CANCELLED"},
+        "SUBMITTED": {"APPROVED", "REJECTED", "CANCELLED"},
+        "APPROVED": set(),
+        "REJECTED": set(),
+        "CANCELLED": set(),
+    }
+    return new in transitions.get(current, set())
+
+
+def compute_employee_annual_balance(
+    db: Session, employee_id: UUID, year: int
+) -> dict[str, Decimal]:
+    from app.models.employee import Employee  # local import to avoid circular
+
+    employee = db.get(Employee, employee_id)
+    if not employee:
+        base = Decimal("0")
+    else:
+        base = employee.annual_leave_days_per_year
+    start = date(year, 1, 1)
+    end = date(year, 12, 31)
+    used = (
+        db.query(func.coalesce(func.sum(LeaveRequest.days), 0))
+        .join(LeaveType, LeaveRequest.type_id == LeaveType.id)
+        .filter(
+            LeaveRequest.employee_id == employee_id,
+            LeaveRequest.status == "APPROVED",
+            LeaveType.is_annual.is_(True),
+            LeaveRequest.start_date >= start,
+            LeaveRequest.start_date <= end,
+        )
+        .scalar()
+    )
+    used = Decimal(used or 0)
+    remaining = base - used
+    if remaining < 0:
+        remaining = Decimal("0")
+    return {"employee_id": employee_id, "year": year, "base": base, "used": used, "remaining": remaining}
+
+
+def set_leave_status(db: Session, id: UUID, new_status: str) -> LeaveRequest | None:
+    req = db.get(LeaveRequest, id)
+    if not req:
+        return None
+    if not _is_transition_allowed(req.status, new_status):
+        raise ValueError("invalid_status")
+    if new_status == "APPROVED":
+        lt = db.get(LeaveType, req.type_id)
+        if lt and lt.is_annual:
+            balance = compute_employee_annual_balance(db, req.employee_id, req.start_date.year)
+            if req.days > balance["remaining"]:
+                raise ValueError("insufficient_balance")
+    req.status = new_status
+    db.commit()
+    db.refresh(req)
+    return req
+
+
+def list_leave_requests(
+    db: Session,
+    page: int,
+    page_size: int,
+    employee_id: UUID | None = None,
+    status: str | None = None,
+    type_id: UUID | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
+) -> tuple[Sequence[LeaveRequest], int]:
+    query = db.query(LeaveRequest)
+    if employee_id:
+        query = query.filter(LeaveRequest.employee_id == employee_id)
+    if status:
+        query = query.filter(LeaveRequest.status == status)
+    if type_id:
+        query = query.filter(LeaveRequest.type_id == type_id)
+    if date_from:
+        query = query.filter(LeaveRequest.start_date >= date_from)
+    if date_to:
+        query = query.filter(LeaveRequest.end_date <= date_to)
+    total = query.count()
+    items = (
+        query.order_by(LeaveRequest.created_at_utc.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+    return items, total


### PR DESCRIPTION
## Summary
- introduce leave type and request tables and models
- implement service logic for leave management with balance checks and status transitions
- expose HR leave APIs and document usage examples

## Testing
- `alembic upgrade head` *(fails: Settings validation errors)*
- `pytest -q` *(fails: multiple IntegrityError and conflict assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4bce220c832d9a4fe41e9fa04e44