### PR TITLE
Ensure UUID primary keys work on SQLite tests

### DIFF
--- a/backend/app/models/_mixins.py
+++ b/backend/app/models/_mixins.py
@@ -1,0 +1,20 @@
+import uuid
+from sqlalchemy import text
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+
+class UUIDPKMixin:
+    """Mixin providing a UUID primary key.
+
+    Uses a Python-side default for SQLite tests while keeping the
+    Postgres ``gen_random_uuid()`` server default for production.
+    """
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        server_default=text("gen_random_uuid()"),
+    )
+

--- a/backend/app/models/quote.py
+++ b/backend/app/models/quote.py
@@ -14,9 +14,10 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 
 from app.db.base import Base
+from app.models._mixins import UUIDPKMixin
 
 
-class Quote(Base):
+class Quote(UUIDPKMixin, Base):
     __tablename__ = "quotes"
     __table_args__ = (
         Index("ix_quotes_partner", "partner_id"),
@@ -31,11 +32,6 @@ class Quote(Base):
         ),
     )
 
-    id = Column(
-        UUID(as_uuid=True),
-        primary_key=True,
-        server_default=text("gen_random_uuid()"),
-    )
     number = Column(Text, nullable=False, unique=True)
     partner_id = Column(
         UUID(as_uuid=True), ForeignKey("partners.id", ondelete="RESTRICT"), nullable=False
@@ -61,7 +57,7 @@ class Quote(Base):
     )
 
 
-class QuoteItem(Base):
+class QuoteItem(UUIDPKMixin, Base):
     __tablename__ = "quote_items"
     __table_args__ = (
         Index("ix_quote_items_quote", "quote_id"),
@@ -77,11 +73,6 @@ class QuoteItem(Base):
         ),
     )
 
-    id = Column(
-        UUID(as_uuid=True),
-        primary_key=True,
-        server_default=text("gen_random_uuid()"),
-    )
     quote_id = Column(
         UUID(as_uuid=True), ForeignKey("quotes.id", ondelete="CASCADE"), nullable=False
     )


### PR DESCRIPTION
## Summary
- add `UUIDPKMixin` with Python-side UUID defaults
- apply mixin to `Quote` and `QuoteItem` models so tests generate IDs without relying on Postgres defaults

## Testing
- `docker compose -f ops/docker-compose.yml exec backend pytest -q` *(fails: command not found)*
- `pytest backend/tests/api/test_quotes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac639e3cdc832dae1507f9bb28fb41