### PR TITLE
Restrict HR leave operations to admins

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@
      -d '{"status":"APPROVED"}'`
    `curl -s http://localhost:8000/hr/leaves/balance/$EMP_ID?year=2024 -H "Authorization: Bearer $TOKEN"`
 
+   **Not:** İzin taleplerinde create/update/delete ve durum değişiklikleri yalnızca
+   adminler tarafından yapılabilir. Çalışanlar kendi taleplerini
+   görüntüleyebilir ancak oluşturamaz veya düzenleyemez.
+
 ## Çoklu Firma (Tenant) – İlk Adım
 
 Tüm isteklerde firma seçimi için `X-Org-Slug` header'ı kullanılır. Varsayılan organizasyon:

--- a/backend/app/api/leaves.py
+++ b/backend/app/api/leaves.py
@@ -8,12 +8,15 @@ from sqlalchemy.orm import Session
 from pydantic import BaseModel
 
 from app.core.deps import (
-    get_current_admin,
     get_current_user,
+    get_current_org,
+    get_current_user_in_org,
+    require_admin,
     get_db,
     get_pagination,
 )
 from app.models.user import User
+from app.models.organization import Organization
 from app.schemas.leave import (
     LeaveTypeCreate,
     LeaveTypeUpdate,
@@ -47,52 +50,73 @@ router = APIRouter(prefix="/hr/leaves", tags=["hr-leaves"])
 
 
 # Leave Types
-@router.get("/types", response_model=LeaveTypeListResponse)
+@router.get(
+    "/types",
+    response_model=LeaveTypeListResponse,
+    dependencies=[Depends(get_current_user_in_org)],
+)
 def list_leave_types_endpoint(
     pagination: tuple[int, int] = Depends(get_pagination),
     search: str | None = None,
     db: Session = Depends(get_db),
-    user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user),
+    current_org: Organization = Depends(get_current_org),
 ):
     page, page_size = pagination
     items, total = list_leave_types(db, page, page_size, search)
     return {"items": items, "total": total, "page": page, "page_size": page_size}
 
 
-@router.post("/types", response_model=LeaveTypePublic, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/types",
+    response_model=LeaveTypePublic,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(get_current_user_in_org), Depends(require_admin)],
+)
 def create_leave_type_endpoint(
     data: LeaveTypeCreate,
     db: Session = Depends(get_db),
-    admin: User = Depends(get_current_admin),
 ):
     try:
         lt = create_leave_type(db, data)
     except IntegrityError:
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="LeaveType with this code already exists")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="LeaveType with this code already exists",
+        )
     return lt
 
 
-@router.put("/types/{type_id}", response_model=LeaveTypePublic)
+@router.put(
+    "/types/{type_id}",
+    response_model=LeaveTypePublic,
+    dependencies=[Depends(get_current_user_in_org), Depends(require_admin)],
+)
 def update_leave_type_endpoint(
     type_id: UUID,
     data: LeaveTypeUpdate,
     db: Session = Depends(get_db),
-    admin: User = Depends(get_current_admin),
 ):
     try:
         lt = update_leave_type(db, type_id, data)
     except IntegrityError:
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="LeaveType with this code already exists")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="LeaveType with this code already exists",
+        )
     if not lt:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="LeaveType not found")
     return lt
 
 
-@router.delete("/types/{type_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/types/{type_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(get_current_user_in_org), Depends(require_admin)],
+)
 def delete_leave_type_endpoint(
     type_id: UUID,
     db: Session = Depends(get_db),
-    admin: User = Depends(get_current_admin),
 ):
     deleted = delete_leave_type(db, type_id)
     if not deleted:
@@ -101,7 +125,11 @@ def delete_leave_type_endpoint(
 
 
 # Leave Requests
-@router.get("/requests", response_model=LeaveRequestListResponse)
+@router.get(
+    "/requests",
+    response_model=LeaveRequestListResponse,
+    dependencies=[Depends(get_current_user_in_org)],
+)
 def list_leave_requests_endpoint(
     pagination: tuple[int, int] = Depends(get_pagination),
     employee_id: UUID | None = None,
@@ -110,11 +138,14 @@ def list_leave_requests_endpoint(
     date_from: date | None = Query(None, alias="from"),
     date_to: date | None = Query(None, alias="to"),
     db: Session = Depends(get_db),
-    user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user),
+    current_org: Organization = Depends(get_current_org),
 ):
     page, page_size = pagination
     items, total = list_leave_requests(
         db,
+        current_user,
+        current_org,
         page,
         page_size,
         employee_id=employee_id,
@@ -126,23 +157,32 @@ def list_leave_requests_endpoint(
     return {"items": items, "total": total, "page": page, "page_size": page_size}
 
 
-@router.get("/requests/{request_id}", response_model=LeaveRequestPublic)
+@router.get(
+    "/requests/{request_id}",
+    response_model=LeaveRequestPublic,
+    dependencies=[Depends(get_current_user_in_org)],
+)
 def get_leave_request_endpoint(
     request_id: UUID,
     db: Session = Depends(get_db),
-    user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user),
+    current_org: Organization = Depends(get_current_org),
 ):
-    req = get_leave_request(db, request_id)
+    req = get_leave_request(db, current_user, current_org, request_id)
     if not req:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="LeaveRequest not found")
     return req
 
 
-@router.post("/requests", response_model=LeaveRequestPublic, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/requests",
+    response_model=LeaveRequestPublic,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(get_current_user_in_org), Depends(require_admin)],
+)
 def create_leave_request_endpoint(
     data: LeaveRequestCreate,
     db: Session = Depends(get_db),
-    admin: User = Depends(get_current_admin),
 ):
     try:
         req = create_leave_request(db, data)
@@ -155,12 +195,15 @@ def create_leave_request_endpoint(
     return req
 
 
-@router.put("/requests/{request_id}", response_model=LeaveRequestPublic)
+@router.put(
+    "/requests/{request_id}",
+    response_model=LeaveRequestPublic,
+    dependencies=[Depends(get_current_user_in_org), Depends(require_admin)],
+)
 def update_leave_request_endpoint(
     request_id: UUID,
     data: LeaveRequestUpdate,
     db: Session = Depends(get_db),
-    admin: User = Depends(get_current_admin),
 ):
     try:
         req = update_leave_request(db, request_id, data)
@@ -177,12 +220,15 @@ def update_leave_request_endpoint(
     return req
 
 
-@router.post("/requests/{request_id}/status", response_model=LeaveRequestPublic)
+@router.post(
+    "/requests/{request_id}/status",
+    response_model=LeaveRequestPublic,
+    dependencies=[Depends(get_current_user_in_org), Depends(require_admin)],
+)
 def change_leave_status_endpoint(
     request_id: UUID,
     body: StatusChange,
     db: Session = Depends(get_db),
-    admin: User = Depends(get_current_admin),
 ):
     try:
         req = set_leave_status(db, request_id, body.status)
@@ -196,12 +242,23 @@ def change_leave_status_endpoint(
     return req
 
 
-@router.get("/balance/{employee_id}", response_model=AnnualBalance)
+@router.get(
+    "/balance/{employee_id}",
+    response_model=AnnualBalance,
+    dependencies=[Depends(get_current_user_in_org)],
+)
 def get_balance_endpoint(
     employee_id: UUID,
     year: int = Query(date.today().year, ge=2000),
     db: Session = Depends(get_db),
-    user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user),
+    current_org: Organization = Depends(get_current_org),
 ):
+    if getattr(current_user, "role", None) != "admin" and getattr(
+        current_user, "employee_id", None
+    ) != employee_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="LeaveRequest not found"
+        )
     balance = compute_employee_annual_balance(db, employee_id, year)
     return balance

--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -48,6 +48,14 @@ def get_current_user(
     return user
 
 
+def require_admin(user: User = Depends(get_current_user)) -> User:
+    if getattr(user, "role", None) != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="admin_only"
+        )
+    return user
+
+
 def get_current_admin(current_user: User = Depends(get_current_user)) -> User:
     if current_user.role != "admin":
         raise HTTPException(

--- a/backend/tests/api/test_leaves_rbac.py
+++ b/backend/tests/api/test_leaves_rbac.py
@@ -1,0 +1,52 @@
+import uuid
+from uuid import uuid4
+
+from app.db.session import SessionLocal
+from app.models.leave_type import LeaveType
+from app.models.employee import Employee
+
+def test_user_cannot_create_leave_request(client, user_token):
+    payload = {
+        "employee_id": str(uuid.uuid4()),
+        "type_id": str(uuid.uuid4()),
+        "start_date": "2025-08-28",
+        "end_date": "2025-08-30",
+    }
+    res = client.post(
+        "/hr/leaves/requests",
+        headers={
+            "Authorization": f"Bearer {user_token}",
+            "X-Org-Slug": "default",
+        },
+        json=payload,
+    )
+    assert res.status_code == 403
+    assert res.json()["detail"] == "admin_only"
+
+
+def test_admin_can_create_leave_request(client, admin_token):
+    db = SessionLocal()
+    lt = LeaveType(id=uuid4(), code="YILLIK", name="Yıllık İzin", is_annual=True)
+    emp = Employee(id=uuid4(), code="EMP1", first_name="John", last_name="Doe")
+    db.add_all([lt, emp])
+    db.commit()
+    db.refresh(lt)
+    db.refresh(emp)
+    payload = {
+        "employee_id": str(emp.id),
+        "type_id": str(lt.id),
+        "start_date": "2025-08-28",
+        "end_date": "2025-08-30",
+    }
+    res = client.post(
+        "/hr/leaves/requests",
+        headers={
+            "Authorization": f"Bearer {admin_token}",
+            "X-Org-Slug": "default",
+        },
+        json=payload,
+    )
+    assert res.status_code == 201
+    body = res.json()
+    assert body["employee_id"] == str(emp.id)
+    db.close()


### PR DESCRIPTION
## Summary
- add `require_admin` dependency to centralize admin-only checks
- guard HR leave routes so only admins may create, update, delete or change status
- limit leave list/get services to current org and user unless admin
- document admin-only policy and add tests for leave RBAC

## Testing
- `pytest tests/api/test_leaves_rbac.py -vv`
- `pytest` *(fails: test_ar.py::test_ar_flow_issue_payment_balance_paid, test_categories.py::test_admin_can_create_and_get_category, test_categories.py::test_list_categories_pagination_search, test_categories.py::test_duplicate_category_conflict, test_dashboard.py::test_dashboard_summary, test_employees.py::test_admin_can_create_and_get_employee, test_employees.py::test_list_employees, test_employees.py::test_duplicate_code_conflict, tests/api/test_leaves_rbac.py::test_admin_can_create_leave_request, test_partners.py::test_admin_can_create_and_get_partner, test_partners.py::test_list_partners_pagination_search_type, test_partners.py::test_user_cannot_modify_partner, test_partners.py::test_tax_number_conflict, test_products.py::test_list_products_pagination_search, test_warehouses_stock.py::test_warehouse_crud_and_rbac, test_warehouses_stock.py::test_stock_movements_and_stock_endpoint)`

------
https://chatgpt.com/codex/tasks/task_e_68ac659889f8832dae3ab7aba836bdb0