### PR TITLE
Refactor order creation and add production workflow

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,1 +1,8 @@
+from app.models.order import Order, OrderItem
+from app.models.production_job import ProductionJob
 
+__all__ = [
+    "Order",
+    "OrderItem",
+    "ProductionJob",
+]

--- a/backend/app/models/order.py
+++ b/backend/app/models/order.py
@@ -82,6 +82,8 @@ class OrderItem(Base):
     description = Column(Text, nullable=True)
     quantity = Column(Numeric(14, 3), nullable=False)
     unit_price = Column(Numeric(14, 2), nullable=False)
+    width = Column(Numeric(14, 2), nullable=False)
+    height = Column(Numeric(14, 2), nullable=False)
     line_discount_rate = Column(Numeric(5, 2), nullable=False, server_default=text("0"))
     tax_rate = Column(Numeric(5, 2), nullable=False, server_default=text("20"))
     line_subtotal = Column(Numeric(14, 2), nullable=False, server_default=text("0"))
@@ -89,3 +91,8 @@ class OrderItem(Base):
     line_total = Column(Numeric(14, 2), nullable=False, server_default=text("0"))
 
     order = relationship("Order", back_populates="items")
+    jobs = relationship(
+        "ProductionJob",
+        back_populates="order_item",
+        cascade="all, delete-orphan",
+    )

--- a/backend/app/models/production_job.py
+++ b/backend/app/models/production_job.py
@@ -1,0 +1,23 @@
+from sqlalchemy import CheckConstraint, Column, DateTime, ForeignKey, Numeric, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from app.db.base import Base
+
+
+class ProductionJob(Base):
+    __tablename__ = "production_jobs"
+    __table_args__ = (
+        CheckConstraint("quantity_required > 0", name="chk_production_job_qty_positive"),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()"))
+    order_item_id = Column(
+        UUID(as_uuid=True), ForeignKey("order_items.id", ondelete="CASCADE"), nullable=False
+    )
+    quantity_required = Column(Numeric(14, 3), nullable=False)
+    created_at_utc = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    order_item = relationship("OrderItem", back_populates="jobs")

--- a/backend/app/schemas/order.py
+++ b/backend/app/schemas/order.py
@@ -12,6 +12,8 @@ class OrderItemBase(BaseModel):
     description: str | None = None
     quantity: Decimal = Field(..., gt=0)
     unit_price: Decimal = Field(..., ge=0)
+    width: Decimal = Field(..., gt=0)
+    height: Decimal = Field(..., gt=0)
     line_discount_rate: Decimal = Field(0, ge=0, le=100)
     tax_rate: Decimal = Field(20, ge=0, le=100)
 
@@ -43,12 +45,18 @@ class OrderUpdate(BaseModel):
     items: list[OrderItemCreate] | None = None
 
 
+class OrderStatusUpdate(BaseModel):
+    status: str
+
+
 class OrderItemPublic(BaseModel):
     id: UUID
     product_id: UUID
     description: str | None
     quantity: Decimal
     unit_price: Decimal
+    width: Decimal
+    height: Decimal
     line_discount_rate: Decimal
     tax_rate: Decimal
     line_subtotal: Decimal


### PR DESCRIPTION
## Summary
- calculate order item totals using dimensions and ensure sequential order numbers
- add production job creation when status changes
- expose endpoint for updating order status

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad56537724832d9feb0f791fc0b954