### PR TITLE
Add basic finance accounts and transaction module

### DIFF
--- a/backend/app/api/finance.py
+++ b/backend/app/api/finance.py
@@ -1,0 +1,55 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.core.deps import get_current_org, get_current_user_in_org, get_db
+from app.models.organization import Organization
+from app.models.user import User
+from app.models.finance import Account
+from app.schemas.finance import (
+    AccountPublic,
+    FinancialTransactionCreate,
+    FinancialTransactionPublic,
+)
+from app.services.finance_service import (
+    FinanceServiceError,
+    record_transaction,
+)
+
+router = APIRouter(prefix="/finance", tags=["finance"])
+
+
+@router.post(
+    "/transactions",
+    response_model=FinancialTransactionPublic,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_transaction(
+    data: FinancialTransactionCreate,
+    db: Session = Depends(get_db),
+    org: Organization = Depends(get_current_org),
+    user: User = Depends(get_current_user_in_org),
+):
+    account = (
+        db.query(Account)
+        .filter(Account.id == data.account_id, Account.organization_id == org.id)
+        .first()
+    )
+    if not account:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="account_not_found")
+    try:
+        tx = record_transaction(db, data, user)
+    except FinanceServiceError as e:
+        if str(e) == "forbidden":
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="account_not_found")
+    return tx
+
+
+@router.get("/accounts", response_model=list[AccountPublic])
+def list_accounts(
+    db: Session = Depends(get_db),
+    org: Organization = Depends(get_current_org),
+    user: User = Depends(get_current_user_in_org),
+):
+    accounts = db.query(Account).filter(Account.organization_id == org.id).all()
+    return accounts

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -11,4 +11,5 @@ from app.models import (
     user,
     organization,
     user_org,
+    finance,
 )  # noqa: E402,F401

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from app.api.categories import router as categories_router
 from app.api.partners import router as partners_router
 from app.api.orders import router as orders_router
 from app.api.dashboard import router as dashboard_router
+from app.api.finance import router as finance_router
 from app.core.security import hash_password
 from app.core.config import settings
 from app.db.session import SessionLocal
@@ -71,3 +72,4 @@ app.include_router(categories_router)
 app.include_router(partners_router)
 app.include_router(orders_router)
 app.include_router(dashboard_router)
+app.include_router(finance_router)

--- a/backend/app/models/finance.py
+++ b/backend/app/models/finance.py
@@ -1,0 +1,45 @@
+from sqlalchemy import Column, DateTime, ForeignKey, Numeric, Text, CheckConstraint, text
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.base import Base
+
+
+class Account(Base):
+    __tablename__ = "accounts"
+    __table_args__ = (
+        CheckConstraint("type IN ('CASH','BANK')", name="chk_account_type"),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()"))
+    organization_id = Column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="RESTRICT"), nullable=False
+    )
+    name = Column(Text, nullable=False)
+    type = Column(Text, nullable=False)
+    current_balance = Column(Numeric(14, 2), nullable=False, server_default=text("0"))
+
+
+class FinancialTransaction(Base):
+    __tablename__ = "financial_transactions"
+    __table_args__ = (
+        CheckConstraint("direction IN ('IN','OUT')", name="chk_fin_tx_direction"),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()"))
+    organization_id = Column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="RESTRICT"), nullable=False
+    )
+    account_id = Column(
+        UUID(as_uuid=True), ForeignKey("accounts.id", ondelete="RESTRICT"), nullable=False
+    )
+    partner_id = Column(
+        UUID(as_uuid=True), ForeignKey("partners.id", ondelete="RESTRICT"), nullable=False
+    )
+    order_id = Column(
+        UUID(as_uuid=True), ForeignKey("orders.id", ondelete="SET NULL"), nullable=True
+    )
+    direction = Column(Text, nullable=False)
+    amount = Column(Numeric(14, 2), nullable=False)
+    transaction_date = Column(DateTime(timezone=True), nullable=False)
+    description = Column(Text, nullable=True)
+    method = Column(Text, nullable=False)

--- a/backend/app/schemas/finance.py
+++ b/backend/app/schemas/finance.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AccountBase(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    type: Literal["CASH", "BANK"]
+
+
+class AccountCreate(AccountBase):
+    pass
+
+
+class AccountPublic(AccountBase):
+    id: UUID
+    organization_id: UUID
+    current_balance: Decimal
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class FinancialTransactionBase(BaseModel):
+    account_id: UUID
+    partner_id: UUID
+    order_id: UUID | None = None
+    direction: Literal["IN", "OUT"]
+    amount: Decimal = Field(..., gt=0)
+    transaction_date: datetime
+    description: str | None = None
+    method: str
+
+
+class FinancialTransactionCreate(FinancialTransactionBase):
+    pass
+
+
+class FinancialTransactionPublic(FinancialTransactionBase):
+    id: UUID
+    organization_id: UUID
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/finance_service.py
+++ b/backend/app/services/finance_service.py
@@ -1,0 +1,57 @@
+from uuid import uuid4
+from decimal import Decimal
+
+from sqlalchemy.orm import Session
+
+from app.models.finance import Account, FinancialTransaction
+from app.models.user import User
+from app.models.user_org import UserOrganization
+from app.schemas.finance import FinancialTransactionCreate
+
+
+class FinanceServiceError(Exception):
+    pass
+
+
+def record_transaction(
+    db: Session, data: FinancialTransactionCreate, current_user: User
+) -> FinancialTransaction:
+    account = db.query(Account).filter(Account.id == data.account_id).first()
+    if not account:
+        raise FinanceServiceError("account_not_found")
+
+    membership = (
+        db.query(UserOrganization)
+        .filter(
+            UserOrganization.user_id == current_user.id,
+            UserOrganization.org_id == account.organization_id,
+        )
+        .first()
+    )
+    if not membership:
+        raise FinanceServiceError("forbidden")
+
+    tx = FinancialTransaction(
+        id=uuid4(),
+        organization_id=account.organization_id,
+        account_id=data.account_id,
+        partner_id=data.partner_id,
+        order_id=data.order_id,
+        direction=data.direction,
+        amount=data.amount,
+        transaction_date=data.transaction_date,
+        description=data.description,
+        method=data.method,
+    )
+
+    current_balance = account.current_balance or Decimal("0")
+    if data.direction == "IN":
+        account.current_balance = current_balance + data.amount
+    else:
+        account.current_balance = current_balance - data.amount
+
+    db.add(tx)
+    db.add(account)
+    db.commit()
+    db.refresh(tx)
+    return tx


### PR DESCRIPTION
## Summary
- add Account and FinancialTransaction models and schemas
- implement finance service to record transactions updating account balances
- expose `/finance/transactions` POST and `/finance/accounts` GET endpoints
- wire finance router into main app

## Testing
- `cd backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad5923af48832d86765735504fc55c